### PR TITLE
Add DEFAULT_VIEWER_TOOL setting and use it in new map configs

### DIFF
--- a/src/GeoNodePy/geonode/maps/models.py
+++ b/src/GeoNodePy/geonode/maps/models.py
@@ -1454,6 +1454,8 @@ class Map(models.Model, PermissionLevelMixin, ThumbnailMixin):
         }
         if self.tools_params:
             config['tools'] = simplejson.loads(self.tools_params)
+        else:
+            config['tools'] = settings.DEFAULT_VIEWER_TOOLS
         if self.portal_params:
             config['portalConfig'] = simplejson.loads(self.portal_params)
         if authenticated == True:

--- a/src/GeoNodePy/geonode/settings.py
+++ b/src/GeoNodePy/geonode/settings.py
@@ -219,6 +219,27 @@ MAP_BASELAYERS = [{
 
 }]
 
+DEFAULT_VIEWER_TOOLS = [{
+    "ptype": "gxp_wmsgetfeatureinfo",
+    "format": "grid",
+    "actionTarget": "main.tbar",
+    "toggleGroup": "map",
+    "layerParams": ["TIME"],
+    "controlOptions": {
+        "hover": True
+    },
+    "outputConfig": {"width": 400, "height": 300}
+}, {
+    "ptype": "gxp_playback",
+    "id": "playback-tool",
+    "outputTarget": "map-bbar",
+    "looped": True,
+    "outputConfig":{
+        "xtype": 'app_playbacktoolbar',
+        "defaults": {"scale": 'medium'}
+    }
+}]
+
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION
I think this is possibly better than having default tools buried inside a function in GeoExplorer.js and not easily configurable.
Do you agree @ischneider 
