### PR TITLE
use style name instead of style object

### DIFF
--- a/geonode/tests/integration.py
+++ b/geonode/tests/integration.py
@@ -537,7 +537,7 @@ class GeoNodeMapTest(TestCase):
         
         # Verify that the styles were deleted
         for style in styles:
-            s = gs_cat.get_style(style)
+            s = gs_cat.get_style(style.name)
             assert s == None
         
         # Verify that the resource was deleted


### PR DESCRIPTION
The style name needs to get passed into the get_style call, not a style
object.
