### PR TITLE
Remove and clean up on the geo explorer application

### DIFF
--- a/src/geonode-client/app/static/script/app/GeoExplorer/Notes.js
+++ b/src/geonode-client/app/static/script/app/GeoExplorer/Notes.js
@@ -103,6 +103,7 @@ GeoExplorer.plugins.Notes = Ext.extend(gxp.plugins.Tool, {
         return GeoExplorer.plugins.Notes.superclass.addActions.apply(this, [{
             text: this.notesText,
             disabled: !id,
+            id: 'notes-button',
             iconCls: this.iconCls,
             menu: new Ext.menu.Menu({
                 id: this.outputConfig.id,

--- a/src/geonode-client/app/static/script/app/mapstory/ToolBar.js
+++ b/src/geonode-client/app/static/script/app/mapstory/ToolBar.js
@@ -1,0 +1,219 @@
+/*global Ext, mapstory, gxp */
+
+(function () {
+    'use strict';
+
+    Ext.ns('mapstory.plugins');
+
+
+    mapstory.plugins.ToolBar = Ext.extend(gxp.plugins.Tool, {
+        ptype: 'ms-tool-bar',
+        saveText: 'Save Map',
+        publishText: 'Publish Map',
+        zoomText: 'Number of zoom levels',
+        wrapDateLineText: 'Wrap dateline',
+        colorText: 'Background color',
+
+        buildSaveForm: function () {
+            var ge = this.target,
+                baseLayer = this.target.mapPanel.map.baseLayer,
+                container = Ext.get(this.target.mapPanel.map.getViewport()),
+                updateMap = function (ge, asCopy) {
+                    var saveForm = Ext.getCmp('saveForm').getForm(),
+                        values = saveForm.getValues();
+                    ge.about.title = values.mapTitle;
+                    ge.about['abstract'] = values.mapAbstract;
+
+                    if (asCopy) {
+                        ge.save(true);
+                    } else { ge.save(); }
+
+                    ge.metadataForm.hide();
+                },
+                saveButton = new Ext.Button({
+                    text: ge.metadataFormSaveText,
+                    handler: function (e) {
+                        updateMap(this, false);
+                    },
+                    scope: ge
+                }),
+                saveAsButton = new Ext.Button({
+                    text: ge.metadataFormSaveAsCopyText,
+                    handler: function (e) {
+                        updateMap(this, true);
+                    },
+                    scope: ge
+                }),
+                saveWindow = new Ext.Window({
+                    title: ge.metaDataHeader,
+                    closeAction: 'hide', // make we just close the
+                                         // window, not destory it
+                    width: 400, // if we don't set a min value chrome miss
+                                // rendered the window
+                    items: [
+                        {
+                            xtype: 'form',
+                            labelAlign: 'top',
+                            bodyStyle: {
+                                padding: '5px'
+                            },
+                            id: 'saveForm',
+                            items: [
+                                {
+                                    xtype: 'textfield',
+                                    id: 'mapTitle',
+                                    width: '95%',
+                                    fieldLabel: ge.metaDataMapTitle,
+                                    allowBlank: false,
+                                    value: ge.about.title,
+                                    listeners: {
+                                        valid: function () {
+                                            saveButton.enable();
+                                            saveAsButton.enable();
+                                        },
+                                        invalid: function () {
+                                            saveButton.disable();
+                                            saveAsButton.disable();
+                                        }
+                                    }
+                                },
+                                {
+                                    xtype: 'textarea',
+                                    id: 'mapAbstract',
+                                    width: '95%',
+                                    height: 200,
+                                    fieldLabel: ge.metaDataMapAbstract,
+                                    value: ge.about['abstract']
+                                },
+                                {
+                                    xtype: 'numberfield',
+                                    allowNegative: false,
+                                    allowDecimals: false,
+                                    fieldLabel: this.zoomText,
+                                    value: baseLayer.numZoomLevels,
+                                    listeners: {
+                                        change: function (fld, value) {
+                                            baseLayer.addOptions({
+                                                numZoomLevels: value
+                                            });
+                                            this.target.mapPanel.
+                                                map.events.
+                                                triggerEvent('changebaselayer', {
+                                                    layer: baseLayer
+                                                });
+                                        },
+                                        scope: this
+                                    }
+                                },
+                                {
+                                    xtype: 'checkbox',
+                                    fieldLabel: this.wrapDateLineText,
+                                    checked: baseLayer.wrapDateLine,
+                                    listeners: {
+                                        check: function (cb, value) {
+                                            baseLayer.wrapDateLine = value;
+                                        },
+                                        scope: this
+                                    }
+                                },
+                                {
+                                    xtype: 'gxp_colorfield',
+                                    fieldLabel: this.colorText,
+                                    value: container.getColor('background-color'),
+                                    listeners: {
+                                        valid: function (field) {
+                                            container.setStyle(
+                                                'background-color',
+                                                field.getValue()
+                                            );
+                                        },
+                                        scope: this
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    bbar: [
+                        "->",
+                        saveButton,
+                        saveAsButton
+                    ]
+                });
+
+            return saveWindow;
+        },
+        getState: function () {
+            var container = Ext.get(this.target.mapPanel.map.getViewport()),
+                baseLayer = this.target.mapPanel.map.baseLayer;
+
+            return {
+                ptype: this.ptype,
+                bgColor: container.getColor('background-color'),
+                numZoomLevels: baseLayer.numZoomLevels,
+                wrapDateLine: baseLayer.wrapDateLine
+            };
+        },
+        addOutput: function () {
+            var container = Ext.get(this.target.mapPanel.map.getViewport()),
+                baseLayer = this.target.mapPanel.map.baseLayer,
+                config = this.initialConfig;
+
+            // why do we guard for these values
+            if (config.bgColor) {
+                container.setStyle(
+                    'background-color',
+                    this.initialConfig.bgColor
+                );
+            }
+
+            if (config.numZoomLevels) {
+                baseLayer.addOptions({
+                    numZoomLevels: config.numZoomLevels
+                });
+                this.target.mapPanel.
+                    map.events.
+                    triggerEvent('changebaselayer', {layer: baseLayer});
+            }
+
+            if (config.wrapDateLine) {
+                baseLayer.wrapDateLine = config.wrapDateLine;
+            }
+
+            return mapstory.plugins.ToolBar.superclass.addOutput.call(this, {
+                xtype: 'toolbar',
+                id: 'ms-toolbar',
+                defaults: {
+                    scale: 'medium',
+                    height: 31 // this seems to match the mapstory
+                              // playback tool
+                },
+                items: [
+                    {
+                        xtype: 'button',
+                        text: this.saveText,
+                        scope: this,
+                        width: 100,
+                        handler: function () {
+                            if (!this.target.metadataForm) {
+                                this.target.metadataForm = this.buildSaveForm();
+                            }
+                            this.target.metadataForm.show();
+                        }
+                    },
+                    {
+                        xtype: 'button',
+                        text: 'Timeline',
+                        scope: this,
+                        handler: function () {
+                            var tl = Ext.getCmp('timeline-container');
+                            tl.toggleCollapse();
+                        }
+                    }
+                ]
+            });
+        }
+    });
+
+    Ext.preg(mapstory.plugins.ToolBar.prototype.ptype, mapstory.plugins.ToolBar);
+
+}());

--- a/src/geonode-client/buildjs.cfg
+++ b/src/geonode-client/buildjs.cfg
@@ -148,6 +148,7 @@ exclude =
     mapstory/LayerViewer.js
     mapstory/Editor.js
     mapstory/CatalogueSource.js
+    mapstory/ToolBar.js
 
 [ux.js]
 root = app/static/script/ux


### PR DESCRIPTION
This commit address the issues in #559. It removes a lot of unused buttons from the map composer application. It also creates a new save widget that combines the old save widget and the map properties widgets.
