### PR TITLE
Enable custom thumbnail persistence.

### DIFF
--- a/geonode/geoserver/signals.py
+++ b/geonode/geoserver/signals.py
@@ -21,6 +21,7 @@
 import errno
 import logging
 import urllib
+import os
 
 from urlparse import urlparse, urljoin
 from socket import error as socket_error
@@ -384,7 +385,13 @@ def geoserver_post_save(instance, sender, **kwargs):
     thumbnail_create_url = ogc_server_settings.LOCATION + \
         "wms/reflect?" + p
 
-    create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url, ogc_client=http_client)
+    thumbnail_name = 'layer-' + instance.uuid + '-thumb.png'
+    thumbnail_dir = os.path.join(settings.MEDIA_ROOT, 'thumbs')
+    thumbnail_path = os.path.join(thumbnail_dir, thumbnail_name)
+
+    if os.path.isfile(thumbnail_path) is False:
+        create_thumbnail(instance, thumbnail_remote_url, thumbnail_create_url,
+                         ogc_client=http_client)
 
     legend_url = ogc_server_settings.PUBLIC_LOCATION + \
         'wms?request=GetLegendGraphic&format=image/png&WIDTH=20&HEIGHT=20&LAYER=' + \


### PR DESCRIPTION
Submitting this as a resolution to the issue described here: https://github.com/GeoNode/geonode/issues/2489

This will also enable custom layer/map thumbnail uploads in Boundless Exchange. 

