### PR TITLE
Apply default permission used in Geofence rule configuration.

### DIFF
--- a/geonode/templates/_permissions_form_js.html
+++ b/geonode/templates/_permissions_form_js.html
@@ -72,12 +72,7 @@
 
   $(function() {
 
-    $('#permissions-body').ready(function(){
-      {% if resource %}
-      $.ajax(
-        "{% url "resource_permissions" resource.id %}",
-        {
-          success: function(data){
+ 	var populate_form = function(data){
             var users = {
               view_resourcebase: [],
               download_resourcebase: [],
@@ -95,8 +90,7 @@
             /*
             * Compile the users fields after receiving the current permissions status from the server
             */
-            var perms = $.parseJSON($.parseJSON(data).permissions);
-
+            var perms = (data.users)? data: $.parseJSON($.parseJSON(data).permissions);
             var perms_users = perms.users;
 
             /*
@@ -189,13 +183,28 @@
             }
             
             addSelectGroups();
+          };
 
+
+
+    $('#permissions-body').ready(function(){
+      {% if resource %}
+      $.ajax(
+        "{% url "resource_permissions" resource.id %}",
+        {
+          success: function(data){
+		populate_form(data);
           }
         }
       );
       {% else %}
-      addSelectUsers();
-      addSelectGroups();
+        var perms_current_user = {"users": {"AnonymousUser": ["view_resourcebase", "download_resourcebase"], 
+    "{{ request.user.username }}": ["view_resourcebase", "download_resourcebase", "change_resourcebase_metadata", 
+    "change_resourcebase", "delete_resourcebase", "change_resourcebase_permissions", "publish_resourcebase", 
+    "change_layer_style", "change_layer_data"]}, "groups": {"anonymous": ["download_resourcebase", 
+    "view_resourcebase"]}};
+    
+       populate_form(perms_current_user);
       {% endif %}
     });
     


### PR DESCRIPTION
This PR performs a refactor of how the upload permissions form is populated by applying the current user permissions for each permission form type by default. It was discovered that this is required in order to successfully configure GeoFence rules for the layer in Geoserver. Without this fix, it is possible for a user to upload a layer and not be able to view it on the layer details page, causing GeoNode permissions and GeoFence access rules to be out of sync.

![screen shot 2017-02-21 at 8 48 12 pm](https://cloud.githubusercontent.com/assets/947403/23195011/3ae36830-f877-11e6-99d5-94033117ef0a.png)
