### PR TITLE
Avoid index out of range error when style is missing

### DIFF
--- a/geonode/layers/admin.py
+++ b/geonode/layers/admin.py
@@ -43,10 +43,12 @@ class LayerAdmin(MediaTranslationAdmin):
         'service_type',
         'title',
         'date',
-        'category')
+        'category',
+        'is_published',
+        'featured')
     list_display_links = ('id',)
-    list_editable = ('title', 'category')
-    list_filter = ('storeType', 'owner', 'category',
+    list_editable = ('title', 'category','is_published','featured')
+    list_filter = ('storeType', 'owner', 'category', 'is_published','featured',
                    'restriction_code_type__identifier', 'date', 'date_type')
     search_fields = ('typename', 'title', 'abstract', 'purpose',)
     filter_horizontal = ('contacts',)

--- a/geonode/layers/templates/layers/layer_detail.html
+++ b/geonode/layers/templates/layers/layer_detail.html
@@ -480,7 +480,9 @@
           {% else %}
           <input type="radio" name="style" id="{{ style.name }}" value="{{ style.title }}"/>
           {% endif %}
+          {% if style %}
           <a href="{{ GEOSERVER_BASE_URL }}{{ style.absolute_url }}" >{{ style.sld_title }}</a>
+          {% endif %}
         </li>
         {% empty %}
         <li>{% trans "No styles associated with this layer" %}</li>


### PR DESCRIPTION
If style is missing, this line throws a index out of range error so we can safely escape it by checking if it is defined first.

![pasted image at 2017_02_21 02_55 pm](https://cloud.githubusercontent.com/assets/947403/23196818/9543c446-f881-11e6-8c95-558664a52e33.png)
