### PR TITLE
Backup and restore

### DIFF
--- a/geonode/base/management/commands/backup.py
+++ b/geonode/base/management/commands/backup.py
@@ -23,20 +23,21 @@ import time
 import shutil
 import requests
 import helpers
+import ConfigParser
 import simplejson as json
+from lxml import html
 
-from requests.auth import HTTPBasicAuth
 from optparse import make_option
 
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
-
 from geonode.utils import designals, resignals
+
+logger = helpers.logger
 
 
 class Command(BaseCommand):
-
     help = 'Backup the GeoNode application data'
 
     option_list = BaseCommand.option_list + (
@@ -46,208 +47,273 @@ class Command(BaseCommand):
             action='store_true',
             dest='ignore_errors',
             default=False,
-            help='Stop after any errors are encountered.'),
+            help='Stop after any errors are encountered.'
+        ),
         make_option(
             '-f',
             '--force',
             action='store_true',
             dest='force_exec',
             default=False,
-            help='Forces the execution without asking for confirmation.'),
+            help='Forces the execution without asking for confirmation.'
+        ),
         make_option(
             '--backup-dir',
             dest='backup_dir',
             type="string",
-            help='Destination folder where to store the backup archive. It must be writable.'))
+            help='Destination folder where to store the backup archive. It must be writable.'
+        ),
+        make_option(
+            '--config_file',
+            dest='config_file',
+            type="string",
+            help='Configuration file to read extra settings from.',
+            default=os.path.join(os.path.abspath(os.path.dirname(__file__)), 'settings.ini')
+        )
+    )
 
     def handle(self, **options):
         # ignore_errors = options.get('ignore_errors')
         force_exec = options.get('force_exec')
         backup_dir = options.get('backup_dir')
+        config_file = options.get('config_file')
+        config = ConfigParser.ConfigParser()
+        config.read(config_file)
+
+        self.pg_dump_cmd = config.get('database', 'pgdump')
+        gs_dump_vector_data = config.getboolean('geoserver', 'dumpvectordata')
+        gs_dump_raster_data = config.getboolean('geoserver', 'dumprasterdata')
+
+        self.app_names = map(str.strip, config.get('fixtures', 'apps').split(','))
+        self.dump_names = map(str.strip, config.get('fixtures', 'dumps').split(','))
 
         if not backup_dir or len(backup_dir) == 0:
             raise CommandError("Destination folder '--backup-dir' is mandatory")
 
-        print "Before proceeding with the Backup, please ensure that:"
-        print " 1. The backend (DB or whatever) is accessible and you have rights"
-        print " 2. The GeoServer is up and running and reachable from this machine"
-        message = 'You want to proceed?'
+        message = 'Do you want to proceed with geonode backup?'
 
         if force_exec or helpers.confirm(prompt=message, resp=False):
             # Create Target Folder
             dir_time_suffix = helpers.get_dir_time_suffix()
-            target_folder = os.path.join(backup_dir, dir_time_suffix)
-            if not os.path.exists(target_folder):
-                os.makedirs(target_folder)
-            os.chmod(target_folder, 0755)
+            self.target_folder = os.path.join(backup_dir, dir_time_suffix)
+            if not os.path.exists(self.target_folder):
+                os.makedirs(self.target_folder)
 
             # Create GeoServer Backup
-            url = settings.OGC_SERVER['default']['PUBLIC_LOCATION']
-            user = settings.OGC_SERVER['default']['USER']
-            passwd = settings.OGC_SERVER['default']['PASSWORD']
-            geoserver_bk_file = os.path.join(target_folder, 'geoserver_catalog.zip')
+            self.url = settings.OGC_SERVER['default']['PUBLIC_LOCATION'].strip('/')
+            self.user = settings.OGC_SERVER['default']['USER']
+            self.passwd = settings.OGC_SERVER['default']['PASSWORD']
+            self.geoserver_bk_file = os.path.join(
+                settings.OGC_SERVER['default']['GEOSERVER_DATA_DIR'],
+                'geoserver_catalog.zip'
+            )
 
-            print "Dumping 'GeoServer Catalog ["+url+"]' into '"+geoserver_bk_file+"'."
-            data = {'backup': {'archiveFile': geoserver_bk_file, 'overwrite': 'true',
-                               'options': {'option': ['BK_BEST_EFFORT=true']}}}
-            headers = {'Content-type': 'application/json'}
-            r = requests.post(url + 'rest/br/backup/', data=json.dumps(data),
-                              headers=headers, auth=HTTPBasicAuth(user, passwd))
-            if (r.status_code > 201):
-                gs_backup = r.json()
-                gs_bk_exec_id = gs_backup['backup']['execution']['id']
-                r = requests.get(url + 'rest/br/backup/' + str(gs_bk_exec_id) + '.json',
-                                 auth=HTTPBasicAuth(user, passwd))
-                if (r.status_code == 200):
-                    gs_backup = r.json()
-                    gs_bk_progress = gs_backup['backup']['execution']['progress']
-                    print gs_bk_progress
-
-                raise ValueError('Could not successfully backup GeoServer catalog [' + url +
-                                 'rest/br/backup/]: ' + str(r.status_code) + ' - ' + str(r.text))
-            else:
-                gs_backup = r.json()
-                gs_bk_exec_id = gs_backup['backup']['execution']['id']
-                r = requests.get(url + 'rest/br/backup/' + str(gs_bk_exec_id) + '.json',
-                                 auth=HTTPBasicAuth(user, passwd))
-                if (r.status_code == 200):
-                    gs_bk_exec_status = gs_backup['backup']['execution']['status']
-                    gs_bk_exec_progress = gs_backup['backup']['execution']['progress']
-                    gs_bk_exec_progress_updated = '0/0'
-                    while (gs_bk_exec_status != 'COMPLETED' and gs_bk_exec_status != 'FAILED'):
-                        if (gs_bk_exec_progress != gs_bk_exec_progress_updated):
-                            gs_bk_exec_progress_updated = gs_bk_exec_progress
-                        r = requests.get(url + 'rest/br/backup/' + str(gs_bk_exec_id) + '.json',
-                                         auth=HTTPBasicAuth(user, passwd))
-                        if (r.status_code == 200):
-                            gs_backup = r.json()
-                            gs_bk_exec_status = gs_backup['backup']['execution']['status']
-                            gs_bk_exec_progress = gs_backup['backup']['execution']['progress']
-                            print str(gs_bk_exec_status) + ' - ' + gs_bk_exec_progress
-                            time.sleep(3)
-                        else:
-                            raise ValueError('Could not successfully backup GeoServer catalog [' + url +
-                                             'rest/br/backup/]: ' + str(r.status_code) + ' - ' + str(r.text))
-                else:
-                    raise ValueError('Could not successfully backup GeoServer catalog [' + url +
-                                     'rest/br/backup/]: ' + str(r.status_code) + ' - ' + str(r.text))
+            self.client = requests.session()
+            self.client.auth = (self.user, self.passwd)
 
             # Dump GeoServer Data
-            if (helpers.GS_DATA_DIR):
-                if (helpers.GS_DUMP_RASTER_DATA):
-                    # Dump '$GS_DATA_DIR/data/geonode'
-                    gs_data_root = os.path.join(helpers.GS_DATA_DIR, 'data', 'geonode')
-                    gs_data_folder = os.path.join(target_folder, 'gs_data_dir', 'data', 'geonode')
-                    if not os.path.exists(gs_data_folder):
-                        os.makedirs(gs_data_folder)
+            self.backup_geoserver_config()
+            if gs_dump_raster_data:
+                self.backup_geoserver_data()
+            self.backup_geogig_config()
+            # Dump vector/postgis data
+            if gs_dump_vector_data:
+                self.backup_postgres()
+            # Dump Fixtures
+            self.backup_django_fixtures()
 
-                    helpers.copy_tree(gs_data_root, gs_data_folder)
-                    print "Dumped GeoServer Uploaded Data from '"+gs_data_root+"'."
+            # Create Final ZIP Archive
+            zip_name = "{}.zip".format(dir_time_suffix)
+            helpers.zip_dir(self.target_folder, os.path.join(backup_dir, zip_name))
 
-            if (helpers.GS_DUMP_VECTOR_DATA):
-                # Dump Vectorial Data from DB
-                datastore = settings.OGC_SERVER['default']['DATASTORE']
-                if (datastore):
-                    ogc_db_name = settings.DATABASES[datastore]['NAME']
-                    ogc_db_user = settings.DATABASES[datastore]['USER']
-                    ogc_db_passwd = settings.DATABASES[datastore]['PASSWORD']
-                    ogc_db_host = settings.DATABASES[datastore]['HOST']
-                    ogc_db_port = settings.DATABASES[datastore]['PORT']
+            # Cleanup Temp Folder
+            shutil.rmtree(self.target_folder)
 
-                    gs_data_folder = os.path.join(target_folder, 'gs_data_dir', 'data', 'geonode')
-                    if not os.path.exists(gs_data_folder):
-                        os.makedirs(gs_data_folder)
+            logger.info("Backup completed")
 
-                    helpers.dump_db(ogc_db_name, ogc_db_user, ogc_db_port, ogc_db_host, ogc_db_passwd, gs_data_folder)
+            return str(os.path.join(backup_dir, dir_time_suffix+'.zip'))
 
-            try:
-                # Deactivate GeoNode Signals
-                print "Deactivating GeoNode Signals..."
-                designals()
-                print "...done!"
+    def parse_html(self, string):
+        tree = html.fromstring(string)
+        elements = tree.xpath('//li/a')
+        return [element.get('href') for element in elements if 'href' in element.keys()]
 
-                # Dump Fixtures
-                for app_name, dump_name in zip(helpers.app_names, helpers.dump_names):
-                    print "Dumping '"+app_name+"' into '"+dump_name+".json'."
-                    # Point stdout at a file for dumping data to.
-                    output = open(os.path.join(target_folder, dump_name+'.json'), 'w')
-                    call_command('dumpdata', app_name, format='json', indent=2, natural=True, stdout=output)
-                    output.close()
+    def backup_geoserver_data(self):
+        gs_data = os.path.join(self.target_folder, 'gs_data')
+        if not os.path.exists(gs_data):
+            os.makedirs(gs_data)
 
-                # Store Media Root
-                media_root = settings.MEDIA_ROOT
-                media_folder = os.path.join(target_folder, helpers.MEDIA_ROOT)
-                if not os.path.exists(media_folder):
-                    os.makedirs(media_folder)
+        resource_url = "{url}/rest/resource/uploads".format(url=self.url)
+        resp = self.client.get(resource_url)
 
-                helpers.copy_tree(media_root, media_folder)
-                print "Saved Media Files from '"+media_root+"'."
+        if resp.status_code == 200:
+            urls = self.parse_html(resp.content)
+            layers = []
+            # Iterate over all the subdirectories in the /uploads directory
+            for upload_url in urls:
+                if '/uploads' in upload_url:
+                    resp = self.client.get("{url}/rest/resource/uploads{uri}".format(
+                        url=self.url, uri=upload_url.split('/uploads')[-1])
+                    )
+                    urls = self.parse_html(resp.content)
+                    has_shpae_file = ['.shp' in file_url for file_url in urls]
+                    # Download all the files if there isn't a shapefile in the directory.
+                    # Will backup rasters among other datasets that have been uploaded.
+                    if True not in has_shpae_file:
+                        for file_url in urls:
+                            if not file_url.endswith('/uploads'):
+                                file_url = "{url}/rest/resource/uploads{uri}".format(
+                                    url=self.url, uri=file_url.split('/uploads')[-1]
+                                )
 
-                # Store Static Root
-                static_root = settings.STATIC_ROOT
-                static_folder = os.path.join(target_folder, helpers.STATIC_ROOT)
-                if not os.path.exists(static_folder):
-                    os.makedirs(static_folder)
+                                resp = self.client.get(file_url)
+                                file_name = os.path.basename(file_url)
+                                output_path = os.path.join(gs_data, file_name)
+                                with open(output_path, 'w') as f:
+                                    f.write(resp.content)
 
-                helpers.copy_tree(static_root, static_folder)
-                print "Saved Static Root from '"+static_root+"'."
+                                layers.append(
+                                    {
+                                        'name': file_name,
+                                        'uri': file_url.split('/resource')[-1]
+                                    }
+                                )
+                                logger.info("backed up {url}".format(url=file_url))
 
-                # Store Static Folders
-                static_folders = settings.STATICFILES_DIRS
-                static_files_folders = os.path.join(target_folder, helpers.STATICFILES_DIRS)
-                if not os.path.exists(static_files_folders):
-                    os.makedirs(static_files_folders)
+            # Create a JSON file with all the files we backed up to help us restore them later
+            with open(os.path.join(gs_data, 'data_backup.json'), 'w') as f:
+                f.write(json.dumps(layers, indent=2))
 
-                for static_files_folder in static_folders:
-                    static_folder = os.path.join(static_files_folders,
-                                                 os.path.basename(os.path.normpath(static_files_folder)))
-                    if not os.path.exists(static_folder):
-                        os.makedirs(static_folder)
+    def backup_geoserver_config(self):
+        backup_url = "{}/rest/br/backup".format(self.url)
 
-                    helpers.copy_tree(static_files_folder, static_folder)
-                    print "Saved Static Files from '"+static_files_folder+"'."
+        logger.info("Dumping GeoServer Catalog {url} into {geoserver_bk_file}".format(
+                           url=self.url, geoserver_bk_file=self.geoserver_bk_file))
+        data = {
+            'backup': {
+                'archiveFile': self.geoserver_bk_file,
+                'overwrite': 'true',
+                'options': {
+                    'option': ['BK_BEST_EFFORT=true']
+                }
+            }
+        }
 
-                # Store Template Folders
-                template_folders = settings.TEMPLATE_DIRS
-                template_files_folders = os.path.join(target_folder, helpers.TEMPLATE_DIRS)
-                if not os.path.exists(template_files_folders):
-                    os.makedirs(template_files_folders)
+        headers = {'Content-type': 'application/json'}
+        resp = self.client.post(backup_url, data=json.dumps(data), headers=headers)
 
-                for template_files_folder in template_folders:
-                    template_folder = os.path.join(template_files_folders,
-                                                   os.path.basename(os.path.normpath(template_files_folder)))
-                    if not os.path.exists(template_folder):
-                        os.makedirs(template_folder)
+        if resp.status_code == 201:
+            backup_obj = resp.json()
+            job_status = backup_obj['backup']['execution']['status']
+            job_id = backup_obj['backup']['execution']['id']
 
-                    helpers.copy_tree(template_files_folder, template_folder)
-                    print "Saved Template Files from '"+template_files_folder+"'."
+            while job_status != 'COMPLETED':
+                if job_status == 'FAILED':
+                    raise ValueError("Geoserver backup failed: {status} - {error}".format(
+                                       status=resp.status_code, error=resp.text))
 
-                # Store Locale Folders
-                locale_folders = settings.LOCALE_PATHS
-                locale_files_folders = os.path.join(target_folder, helpers.LOCALE_PATHS)
-                if not os.path.exists(locale_files_folders):
-                    os.makedirs(locale_files_folders)
+                job_id = backup_obj['backup']['execution']['id']
+                resp = self.client.get("{url}/{job_id}.json".format(url=backup_url, job_id=job_id))
 
-                for locale_files_folder in locale_folders:
-                    locale_folder = os.path.join(locale_files_folders,
-                                                 os.path.basename(os.path.normpath(locale_files_folder)))
-                    if not os.path.exists(locale_folder):
-                        os.makedirs(locale_folder)
+                if resp.status_code == 200:
+                    backup_obj = resp.json()
+                    job_status = backup_obj['backup']['execution']['status']
+                    job_progress = backup_obj['backup']['execution']['progress']
+                    logger.info("Runnig Geoserver Backup: {status} - {progress}".format(
+                                       status=job_status, progress=job_progress))
+                    time.sleep(3)
+                else:
+                    raise ValueError('Failed while waiting for Geoserver catalog backup: {status} - {error}'.format(
+                                       status=resp.status_code, error=resp.text))
 
-                    helpers.copy_tree(locale_files_folder, locale_folder)
-                    print "Saved Locale Files from '"+locale_files_folder+"'."
+            resp = self.client.get("{url}/{job_id}.zip".format(url=backup_url, job_id=job_id))
 
-                # Create Final ZIP Archive
-                helpers.zip_dir(target_folder, os.path.join(backup_dir, dir_time_suffix+'.zip'))
+            if resp.status_code == 200:
+                gs_backup_path = os.path.join(self.target_folder, os.path.basename(self.geoserver_bk_file))
+                with open(gs_backup_path, 'w') as f:
+                    f.write(resp.content)
+                logger.info("Exported Geoserver backup to {}".format(gs_backup_path))
+            else:
+                raise ValueError('Failed to download Geoserver backup: {status} - {error}'.format(
+                                   status=resp.status_code, error=resp.text))
+        else:
+            raise ValueError('Failed to generate Geoserver backup: {status} - {error}'.format(
+                               status=resp.status_code, error=resp.text))
 
-                # Cleanup Temp Folder
-                shutil.rmtree(target_folder)
+    def backup_geogig_config(self):
+        resp = self.client.get("{}/rest/resource/geogig/config/repos".format(self.url))
+        geogig_backup_dir = os.path.join(self.target_folder, 'gs_data/geogig_repos')
+        if resp.status_code == 200:
+            if not os.path.exists(geogig_backup_dir):
+                os.makedirs(geogig_backup_dir)
 
-                print "Backup Finished. Archive generated."
+            urls = self.parse_html(resp.content)
+            for url in urls:
+                if '/repos' in url:
+                    repo_url = "{base_url}/rest/resource/geogig{repo_uri}".format(
+                        base_url=self.url, repo_uri=url.split('/geogig')[-1])
 
-                return str(os.path.join(backup_dir, dir_time_suffix+'.zip'))
-            finally:
-                # Reactivate GeoNode Signals
-                print "Reactivating GeoNode Signals..."
-                resignals()
-                print "...done!"
+                    resp = self.client.get(repo_url)
+
+                    if resp.status_code == 200:
+                        with open(os.path.join(geogig_backup_dir, os.path.basename(repo_url)), 'w') as f:
+                            f.write(resp.content)
+
+            logger.info("Finished exporting Geogig repo config")
+
+    def backup_postgres(self):
+        # Dump Vectorial Data from DB
+        datastore = settings.OGC_SERVER['default']['DATASTORE']
+        if datastore:
+            ogc_db_obj = settings.DATABASES[datastore]
+
+            ogc_db_name = ogc_db_obj['NAME']
+            ogc_db_user = ogc_db_obj['USER']
+            ogc_db_passwd = ogc_db_obj['PASSWORD']
+            ogc_db_host = ogc_db_obj['HOST']
+            ogc_db_port = ogc_db_obj['PORT']
+
+            schemas_to_backup = ['public']
+
+            if 'OPTIONS' in ogc_db_obj and 'options' in ogc_db_obj['OPTIONS']:
+                search_path = ogc_db_obj['OPTIONS']['options'].split('=')[-1]
+                schemas_to_backup = map(str.strip, search_path.split(','))
+
+            gs_data_folder = os.path.join(self.target_folder, 'gs_data')
+            if not os.path.exists(gs_data_folder):
+                os.makedirs(gs_data_folder)
+
+            helpers.dump_db(
+                ogc_db_name,
+                ogc_db_user,
+                ogc_db_passwd,
+                gs_data_folder,
+                ogc_db_port,
+                ogc_db_host,
+                schemas_to_backup,
+                self.pg_dump_cmd
+            )
+
+    def backup_django_fixtures(self):
+        try:
+            # Deactivate GeoNode Signals
+            designals()
+
+            # Dump Fixtures
+            for app_name, dump_name in zip(self.app_names, self.dump_names):
+                logger.info("dumping django fixture {}".format(app_name))
+                # Point stdout at a file for dumping data to.
+                output = open(os.path.join(self.target_folder, dump_name+'.json'), 'w')
+                call_command('dumpdata', app_name, format='json', indent=2, natural=True, stdout=output)
+                output.close()
+
+            # Store Media Root
+            media_root = settings.MEDIA_ROOT
+            media_folder = os.path.join(self.target_folder, helpers.MEDIA_ROOT)
+            if not os.path.exists(media_folder):
+                os.makedirs(media_folder)
+
+            helpers.copy_tree(media_root, media_folder)
+        finally:
+            # Reactivate GeoNode Signals
+            resignals()

--- a/geonode/base/management/commands/restore.py
+++ b/geonode/base/management/commands/restore.py
@@ -26,8 +26,8 @@ import requests
 import helpers
 import tempfile
 import simplejson as json
+import ConfigParser
 
-from requests.auth import HTTPBasicAuth
 from optparse import make_option
 
 from geonode.utils import designals, resignals
@@ -35,6 +35,8 @@ from geonode.utils import designals, resignals
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
+
+logger = helpers.logger
 
 
 class Command(BaseCommand):
@@ -48,32 +50,63 @@ class Command(BaseCommand):
             action='store_true',
             dest='ignore_errors',
             default=False,
-            help='Stop after any errors are encountered.'),
+            help='Stop after any errors are encountered.'
+        ),
         make_option(
             '-f',
             '--force',
             action='store_true',
             dest='force_exec',
             default=False,
-            help='Forces the execution without asking for confirmation.'),
+            help='Forces the execution without asking for confirmation.'
+        ),
         make_option(
             '--backup-file',
             dest='backup_file',
             type="string",
-            help='Backup archive containing GeoNode data to restore.'))
+            help='Backup archive containing GeoNode data to restore.'
+        ),
+        make_option(
+            '--config_file',
+            dest='config_file',
+            type="string",
+            help='Configuration file to read extra settings from.',
+            default=os.path.join(os.path.abspath(os.path.dirname(__file__)), 'settings.ini')
+        ),
+        make_option(
+            '--clean_data_db',
+            dest='clean_data_db',
+            action='store_true',
+            default=True,
+            help='If we should drop all existing data in our data/ogc database before restoring.',
+        ),
+        make_option(
+            '--clean_django_db',
+            dest='clean_django_db',
+            action='store_true',
+            default=False,
+            help='If we should clear most existing data from the django database before importing the fixtures.',
+        )
+    )
 
     def handle(self, **options):
         # ignore_errors = options.get('ignore_errors')
         force_exec = options.get('force_exec')
         backup_file = options.get('backup_file')
+        self.clean_data_db = options.get('clean_data_db')
+        self.clean_django_db = options.get('clean_django_db')
+        config_file = options.get('config_file')
+        config = ConfigParser.ConfigParser()
+        config.read(config_file)
+
+        self.pg_restore_cmd = config.get('database', 'pgrestore')
+        self.app_names = map(str.strip, config.get('fixtures', 'apps').split(','))
+        self.dump_names = map(str.strip, config.get('fixtures', 'dumps').split(','))
 
         if not backup_file or len(backup_file) == 0:
             raise CommandError("Backup archive '--backup-file' is mandatory")
 
-        print "Before proceeding with the Restore, please ensure that:"
-        print " 1. The backend (DB or whatever) is accessible and you have rights"
-        print " 2. The GeoServer is up and running and reachable from this machine"
-        message = 'WARNING: The restore will overwrite ALL GeoNode data. You want to proceed?'
+        message = 'WARNING: The restore may overwrite ALL GeoNode data. Do you want to proceed?'
         if force_exec or helpers.confirm(prompt=message, resp=False):
             # Create Target Folder
             restore_folder = os.path.join(tempfile.gettempdir(), 'restore')
@@ -81,252 +114,218 @@ class Command(BaseCommand):
                 os.makedirs(restore_folder)
 
             # Extract ZIP Archive to Target Folder
-            target_folder = helpers.unzip_file(backup_file, restore_folder)
+            self.target_folder = helpers.unzip_file(backup_file, restore_folder)
 
             # Restore GeoServer Catalog
-            url = settings.OGC_SERVER['default']['PUBLIC_LOCATION']
+            self.url = settings.OGC_SERVER['default']['PUBLIC_LOCATION'].strip('/')
             user = settings.OGC_SERVER['default']['USER']
             passwd = settings.OGC_SERVER['default']['PASSWORD']
-            geoserver_bk_file = os.path.join(target_folder, 'geoserver_catalog.zip')
+            self.client = requests.session()
+            self.client.auth = (user, passwd)
 
-            print "Restoring 'GeoServer Catalog ["+url+"]' into '"+geoserver_bk_file+"'."
-            if not os.path.exists(geoserver_bk_file):
-                raise ValueError('Could not find GeoServer Backup file [' + geoserver_bk_file + ']')
+            self.restore_geoserver_config()
+            self.restore_geogig_config()
+            self.restore_geoserver_data()
+            self.restore_postgres()
+            self.restore_django()
 
-            # Best Effort Restore: 'options': {'option': ['BK_BEST_EFFORT=true']}
-            data = {'restore': {'archiveFile': geoserver_bk_file, 'options': {}}}
-            headers = {'Content-type': 'application/json'}
-            r = requests.post(url + 'rest/br/restore/', data=json.dumps(data),
-                              headers=headers, auth=HTTPBasicAuth(user, passwd))
-            if (r.status_code > 201):
-                gs_backup = r.json()
-                gs_bk_exec_id = gs_backup['restore']['execution']['id']
-                r = requests.get(url + 'rest/br/restore/' + str(gs_bk_exec_id) + '.json',
-                                 auth=HTTPBasicAuth(user, passwd))
-                if (r.status_code == 200):
-                    gs_backup = r.json()
-                    gs_bk_progress = gs_backup['restore']['execution']['progress']
-                    print gs_bk_progress
+            shutil.rmtree(restore_folder)
+            logger.info("Restore finished")
 
-                raise ValueError('Could not successfully restore GeoServer catalog [' + url +
-                                 'rest/br/restore/]: ' + str(r.status_code) + ' - ' + str(r.text))
-            else:
-                gs_backup = r.json()
-                gs_bk_exec_id = gs_backup['restore']['execution']['id']
-                r = requests.get(url + 'rest/br/restore/' + str(gs_bk_exec_id) + '.json',
-                                 auth=HTTPBasicAuth(user, passwd))
-                if (r.status_code == 200):
-                    gs_bk_exec_status = gs_backup['restore']['execution']['status']
-                    gs_bk_exec_progress = gs_backup['restore']['execution']['progress']
-                    gs_bk_exec_progress_updated = '0/0'
-                    while (gs_bk_exec_status != 'COMPLETED' and gs_bk_exec_status != 'FAILED'):
-                        if (gs_bk_exec_progress != gs_bk_exec_progress_updated):
-                            gs_bk_exec_progress_updated = gs_bk_exec_progress
-                        r = requests.get(url + 'rest/br/restore/' + str(gs_bk_exec_id) + '.json',
-                                         auth=HTTPBasicAuth(user, passwd))
-                        if (r.status_code == 200):
-                            gs_backup = r.json()
-                            gs_bk_exec_status = gs_backup['restore']['execution']['status']
-                            gs_bk_exec_progress = gs_backup['restore']['execution']['progress']
-                            print str(gs_bk_exec_status) + ' - ' + gs_bk_exec_progress
-                            time.sleep(3)
-                        else:
-                            raise ValueError('Could not successfully restore GeoServer catalog [' + url +
-                                             'rest/br/restore/]: ' + str(r.status_code) + ' - ' + str(r.text))
-                else:
-                    raise ValueError('Could not successfully restore GeoServer catalog [' + url +
-                                     'rest/br/restore/]: ' + str(r.status_code) + ' - ' + str(r.text))
+    def restore_django(self):
+        # Prepare Target DB
 
-            # Restore GeoServer Data
-            if (helpers.GS_DATA_DIR):
-                if (helpers.GS_DUMP_RASTER_DATA):
-                    # Restore '$GS_DATA_DIR/data/geonode'
-                    gs_data_root = os.path.join(helpers.GS_DATA_DIR, 'data', 'geonode')
-                    gs_data_folder = os.path.join(target_folder, 'gs_data_dir', 'data', 'geonode')
+        logger.info("Restoring django")
+        django_db_obj = settings.DATABASES['default']
+        db_name = django_db_obj['NAME']
+        db_user = django_db_obj['USER']
+        db_port = django_db_obj['PORT']
+        db_host = django_db_obj['HOST']
+        db_passwd = django_db_obj['PASSWORD']
 
-                    try:
-                        shutil.rmtree(gs_data_root)
-                    except:
-                        pass
+        schema_name = 'public'
 
-                    if not os.path.exists(gs_data_root):
-                        os.makedirs(gs_data_root)
+        if 'OPTIONS' in django_db_obj and 'options' in django_db_obj['OPTIONS']:
+            search_path = django_db_obj['OPTIONS']['options'].split('=')[-1]
+            schema_name = search_path.split(',')[0]
 
-                    helpers.copy_tree(gs_data_folder, gs_data_root)
-                    helpers.chmod_tree(gs_data_root)
-                    print "GeoServer Uploaded Data Restored to '"+gs_data_root+"'."
-
-            if (helpers.GS_DUMP_VECTOR_DATA):
-                # Restore Vectorial Data from DB
-                datastore = settings.OGC_SERVER['default']['DATASTORE']
-                if (datastore):
-                    ogc_db_name = settings.DATABASES[datastore]['NAME']
-                    ogc_db_user = settings.DATABASES[datastore]['USER']
-                    ogc_db_passwd = settings.DATABASES[datastore]['PASSWORD']
-                    ogc_db_host = settings.DATABASES[datastore]['HOST']
-                    ogc_db_port = settings.DATABASES[datastore]['PORT']
-
-                    gs_data_folder = os.path.join(target_folder, 'gs_data_dir', 'data', 'geonode')
-
-                    helpers.restore_db(ogc_db_name, ogc_db_user, ogc_db_port, ogc_db_host,
-                                       ogc_db_passwd, gs_data_folder)
-
-            # Prepare Target DB
+        if self.clean_django_db:
             try:
-                call_command('migrate', interactive=False, load_initial_data=False)
                 call_command('flush', interactive=False, load_initial_data=False)
-
-                db_name = settings.DATABASES['default']['NAME']
-                db_user = settings.DATABASES['default']['USER']
-                db_port = settings.DATABASES['default']['PORT']
-                db_host = settings.DATABASES['default']['HOST']
-                db_passwd = settings.DATABASES['default']['PASSWORD']
-
-                helpers.patch_db(db_name, db_user, db_port, db_host, db_passwd)
+                call_command('migrate', interactive=False, load_initial_data=False)
             except:
                 traceback.print_exc()
 
-            try:
-                # Deactivate GeoNode Signals
-                print "Deactivating GeoNode Signals..."
-                designals()
-                print "...done!"
+        helpers.patch_db(db_name, db_user, db_port, db_host, db_passwd, schema=schema_name)
 
-                # Restore Fixtures
-                for app_name, dump_name in zip(helpers.app_names, helpers.dump_names):
-                    fixture_file = os.path.join(target_folder, dump_name+'.json')
+        try:
+            # Deactivate GeoNode Signals
+            designals()
 
-                    print "Deserializing "+fixture_file
-                    try:
-                        call_command('loaddata', fixture_file, app_label=app_name)
-                    except:
-                        traceback.print_exc()
-                        print "WARNING: No valid fixture data found for '"+dump_name+"'."
-                        # helpers.load_fixture(app_name, fixture_file)
-
-                # Restore Media Root
-                media_root = settings.MEDIA_ROOT
-                media_folder = os.path.join(target_folder, helpers.MEDIA_ROOT)
+            # Restore Fixtures
+            for dump_name in self.dump_names:
+                fixture_file = os.path.join(self.target_folder, dump_name+'.json')
 
                 try:
-                    shutil.rmtree(media_root)
-                except:
-                    pass
-
-                if not os.path.exists(media_root):
-                    os.makedirs(media_root)
-
-                helpers.copy_tree(media_folder, media_root)
-                helpers.chmod_tree(media_root)
-                print "Media Files Restored into '"+media_root+"'."
-
-                # Restore Static Root
-                static_root = settings.STATIC_ROOT
-                static_folder = os.path.join(target_folder, helpers.STATIC_ROOT)
-
-                try:
-                    shutil.rmtree(static_root)
-                except:
-                    pass
-
-                if not os.path.exists(static_root):
-                    os.makedirs(static_root)
-
-                helpers.copy_tree(static_folder, static_root)
-                helpers.chmod_tree(static_root)
-                print "Static Root Restored into '"+static_root+"'."
-
-                # Restore Static Root
-                static_root = settings.STATIC_ROOT
-                static_folder = os.path.join(target_folder, helpers.STATIC_ROOT)
-
-                try:
-                    shutil.rmtree(static_root)
-                except:
-                    pass
-
-                if not os.path.exists(static_root):
-                    os.makedirs(static_root)
-
-                helpers.copy_tree(static_folder, static_root)
-                helpers.chmod_tree(static_root)
-                print "Static Root Restored into '"+static_root+"'."
-
-                # Restore Static Folders
-                static_folders = settings.STATICFILES_DIRS
-                static_files_folders = os.path.join(target_folder, helpers.STATICFILES_DIRS)
-
-                for static_files_folder in static_folders:
-                    try:
-                        shutil.rmtree(static_files_folder)
-                    except:
-                        pass
-
-                    if not os.path.exists(static_files_folder):
-                        os.makedirs(static_files_folder)
-
-                    helpers.copy_tree(os.path.join(static_files_folders,
-                                                   os.path.basename(os.path.normpath(static_files_folder))),
-                                      static_files_folder)
-                    helpers.chmod_tree(static_files_folder)
-                    print "Static Files Restored into '"+static_files_folder+"'."
-
-                # Restore Template Folders
-                template_folders = settings.TEMPLATE_DIRS
-                template_files_folders = os.path.join(target_folder, helpers.TEMPLATE_DIRS)
-
-                for template_files_folder in template_folders:
-                    try:
-                        shutil.rmtree(template_files_folder)
-                    except:
-                        pass
-
-                    if not os.path.exists(template_files_folder):
-                        os.makedirs(template_files_folder)
-
-                    helpers.copy_tree(os.path.join(template_files_folders,
-                                                   os.path.basename(os.path.normpath(template_files_folder))),
-                                      template_files_folder)
-                    helpers.chmod_tree(template_files_folder)
-                    print "Template Files Restored into '"+template_files_folder+"'."
-
-                # Restore Locale Folders
-                locale_folders = settings.LOCALE_PATHS
-                locale_files_folders = os.path.join(target_folder, helpers.LOCALE_PATHS)
-
-                for locale_files_folder in locale_folders:
-                    try:
-                        shutil.rmtree(locale_files_folder)
-                    except:
-                        pass
-
-                    if not os.path.exists(locale_files_folder):
-                        os.makedirs(locale_files_folder)
-
-                    helpers.copy_tree(os.path.join(locale_files_folders,
-                                                   os.path.basename(os.path.normpath(locale_files_folder))),
-                                      locale_files_folder)
-                    helpers.chmod_tree(locale_files_folder)
-                    print "Locale Files Restored into '"+locale_files_folder+"'."
-
-                # Cleanup DB
-                try:
-                    db_name = settings.DATABASES['default']['NAME']
-                    db_user = settings.DATABASES['default']['USER']
-                    db_port = settings.DATABASES['default']['PORT']
-                    db_host = settings.DATABASES['default']['HOST']
-                    db_passwd = settings.DATABASES['default']['PASSWORD']
-
-                    helpers.cleanup_db(db_name, db_user, db_port, db_host, db_passwd)
+                    call_command('loaddata', fixture_file)
                 except:
                     traceback.print_exc()
+                    logger.warning("Django fixture {} can't be restored".format(dump_name))
 
-                print "Restore finished. Please find restored files and dumps into:"
+            # Restore Media Root
+            media_root = settings.MEDIA_ROOT
+            media_folder = os.path.join(self.target_folder, helpers.MEDIA_ROOT)
 
-                return str(target_folder)
+            try:
+                shutil.rmtree(media_root)
+            except:
+                pass
 
-            finally:
-                # Reactivate GeoNode Signals
-                print "Reactivating GeoNode Signals..."
-                resignals()
-                print "...done!"
+            if not os.path.exists(media_root):
+                os.makedirs(media_root)
+
+            helpers.copy_tree(media_folder, media_root)
+            helpers.chmod_tree(media_root)
+
+            # Cleanup DB
+            try:
+                helpers.cleanup_db(db_name, db_user, db_port, db_host, db_passwd, schema=schema_name)
+            except:
+                traceback.print_exc()
+
+        finally:
+            # Reactivate GeoNode Signals
+            resignals()
+            logger.info("Django restore complete")
+
+    def restore_geoserver_config(self):
+        backup_file = os.path.join(self.target_folder, 'geoserver_catalog.zip')
+        logger.info("Restoring Geoserver configuration")
+
+        if not os.path.exists(backup_file):
+            raise ValueError('Could not find GeoServer Backup file {}'.format(backup_file))
+
+        data = {
+            'restore': {
+                'archiveFile': backup_file,
+                'options': {
+                    'option': [
+                        'BK_BEST_EFFORT=true'
+                    ]
+                }
+            }
+        }
+
+        headers = {'Content-type': 'application/json'}
+        restore_url = '{}/rest/br/restore'.format(self.url)
+        resp = self.client.post(restore_url, data=json.dumps(data), headers=headers)
+
+        if resp.status_code == 201:
+            restore_obj = resp.json()
+            job_id = restore_obj['restore']['execution']['id']
+            job_id_url = '{restore_url}/{job_id}.json'.format(restore_url=restore_url, job_id=job_id)
+            resp = self.client.get(job_id_url)
+
+            if resp.status_code == 200:
+                job_status = restore_obj['restore']['execution']['status']
+
+                while job_status != 'COMPLETED':
+                    if job_status == 'FAILED':
+                        raise ValueError("Geoserver restore failed: {status} - {error}".format(
+                                           status=resp.status_code, error=resp.text))
+
+                    resp = self.client.get(job_id_url)
+                    if resp.status_code == 200:
+                        restore_obj = resp.json()
+                        job_status = restore_obj['restore']['execution']['status']
+                        time.sleep(3)
+                    else:
+                        raise ValueError("Geoserver restore failed: {status} - {error}".format(
+                                           status=resp.status_code, error=resp.text))
+                print "Geoserver configuration restore was successful"
+            else:
+                raise ValueError("Geoserver restore failed: {status} - {error}".format(
+                                           status=resp.status_code, error=resp.text))
+        else:
+            raise ValueError('Failed to restore Geoserver backup: {status} - {error}'.format(
+                               status=resp.status_code, error=resp.text))
+        logger.info("Geoserver configuration restore is complete")
+
+    def restore_geogig_config(self):
+        backup_dir = os.path.join(self.target_folder, 'gs_data/geogig_repos')
+        if os.path.exists(backup_dir):
+            backup_files = [os.path.join(backup_dir, f) for f in os.listdir(backup_dir)
+                            if os.path.isfile(os.path.join(backup_dir, f))]
+
+            for f in backup_files:
+                obj_url = "{base_url}/rest/resource/geogig/config/repos/{repo_id}".format(
+                          base_url=self.url, repo_id=os.path.basename(f))
+
+                headers = {'Content-type': 'application/xml'}
+                resp = self.client.put(obj_url, data=open(f), headers=headers)
+                if resp.status_code != 201:
+                    raise ValueError('Failed to restore Geogig repo config {path}: {status} - {error}'.format(
+                                       path=f, status=resp.status_code, error=resp.text))
+
+            logger.info("Geoserver Geogig config restore complete")
+
+    def restore_geoserver_data(self):
+        # Restore GeoServer Data
+        gs_backup_dir = os.path.join(self.target_folder, 'gs_data')
+        json_file = os.path.join(gs_backup_dir, 'data_backup.json')
+        data = None
+        if os.path.isfile(json_file):
+            logger.info("Restoring Geoserver data")
+            with open(json_file) as f:
+                data = json.load(f)
+
+            if data is not None:
+                headers = {'Content-type': 'application/xml'}
+                base_url = "{}/rest/resource".format(self.url)
+                for obj in data:
+                    obj_url = "{base_url}{uri}".format(base_url=base_url, uri=obj['uri'])
+                    obj_path = os.path.join(gs_backup_dir, obj['name'])
+                    resp = self.client.put(obj_url, data=open(obj_path), headers=headers)
+
+                    if resp.status_code != 201:
+                        raise ValueError('Failed to restore Geoserver data {name}: {status} - {error}'.format(
+                                           name=obj['name'], status=resp.status_code, error=resp.text))
+            logger.info("Geoserver data restore complete")
+
+    def restore_postgres(self):
+        # Restore Vectorial Data from DB
+        datastore = settings.OGC_SERVER['default']['DATASTORE']
+        if datastore:
+            ogc_db_obj = settings.DATABASES[datastore]
+
+            ogc_db_name = ogc_db_obj['NAME']
+            ogc_db_user = ogc_db_obj['USER']
+            ogc_db_passwd = ogc_db_obj['PASSWORD']
+            ogc_db_host = ogc_db_obj['HOST']
+            ogc_db_port = ogc_db_obj['PORT']
+
+            # schemas_to_restore = ['public']
+
+            # if 'OPTIONS' in ogc_db_obj and 'options' in ogc_db_obj['OPTIONS']:
+            #    search_path = ogc_db_obj['OPTIONS']['options'].split('=')[-1]
+            #    schemas_to_restore = map(str.strip, search_path.split(','))
+
+            dump_dir = os.path.join(self.target_folder, 'gs_data')
+            included_extenstions = ['dump', 'sql']
+            backup_files = [os.path.join(dump_dir, fn) for fn in os.listdir(dump_dir)
+                            if any(fn.endswith(ext) for ext in included_extenstions)]
+
+            if backup_files:
+                logger.info("Restoring data/ogc database")
+                helpers.restore_db(
+                    ogc_db_name,
+                    ogc_db_user,
+                    ogc_db_passwd,
+                    backup_files,
+                    self.pg_restore_cmd,
+                    ogc_db_port,
+                    ogc_db_host,
+                    self.clean_data_db
+                )
+
+                logger.info("data/ogc database restore complete")

--- a/geonode/base/management/commands/settings.ini
+++ b/geonode/base/management/commands/settings.ini
@@ -9,9 +9,9 @@ dumprasterdata = yes
 
 [fixtures]
 #NOTE: Order is important
-apps   = people,account,avatar.avatar,base.backup,base.license,base.topiccategory,base.region,base.resourcebase,base.contactrole,base.link,base.restrictioncodetype,base.spatialrepresentationtype,guardian.userobjectpermission,guardian.groupobjectpermission,layers.uploadsession,layers.style,layers.layer,layers.attribute,layers.layerfile,maps.map,maps.maplayer,maps.mapsnapshot,documents.document,taggit
+apps   = core.thumbnailimage,themes.theme,taggit.tag,taggit.taggeditem,agon_ratings.overallrating,actstream.action,user_messages.thread,base.hierarchicalkeyword,layers.style,auth.group,guardian.groupobjectpermission,people.profile,groups.groupprofile,groups.groupmember,groups.groupinvitation,guardian.userobjectpermission,user_messages.message,user_messages.userthread,agon_ratings.rating,dialogos.comment,avatar.avatar,account.accountdeletion,account.emailaddress,account.account,base.resourcebase,base.taggedcontentitem,base.link,layers.uploadsession,layers.layerfile,layers.layer,layers.attribute,maps.map,maps.maplayer,base.contactrole,maps.mapsnapshot,documents.document,upload.upload
 
-dumps  = people,accounts,avatars,backups,licenses,topiccategories,regions,resourcebases,contactroles,links,restrictioncodetypes,spatialrepresentationtypes,useropermissions,groupopermissions,uploadsessions,styles,layers,attributes,layerfiles,maps,maplayers,mapsnapshots,documents,tags
+dumps  = core_thumbnailimage,themes_theme,taggit_tag,taggit_taggeditem,agon_ratings_overallrating,actstream_action,user_messages_thread,base_hierarchicalkeyword,layers_style,auth_group,guardian_groupobjectpermission,people_profile,groups_groupprofile,groups_groupmember,groups_groupinvitation,guardian_userobjectpermission,user_messages_message,user_messages_userthread,agon_ratings_rating,dialogos_comment,avatar_avatar,account_accountdeletion,account_emailaddress,account_account,base_resourcebase,base_taggedcontentitem,base_link,layers_uploadsession,layers_layerfile,layers_layer,layers_attribute,maps_map,maps_maplayer,base_contactrole,maps_mapsnapshot,documents_document,upload_upload
 
 # Migrate from GN 2.0 to GN 2.4
 #migrations = base.resourcebase,layers.layer,layers.attribute,maps.map,maps.maplayer


### PR DESCRIPTION
This refactors the existing backup and restore functionality.

- Don't require backup and restore to run under a specific user 
- Move config file reader to backup/restore scripts directly and provide an override (```--config_file```)
- Backup/Restore Geoserver raster data via REST instead of file system (Will backup anything but shapefiles, and will probably have to be modfied to support osgeo importer)
- Backup/Restore Geogig repo configuration via REST
- Backup/Restore Postgis and Geogig data
- Database operations are now schema aware
- Don't backup base Django data already created on inital install
- Add more applications/data that are processed by default
-  Restore has two new command line options:
```--clean_data_db``` - Will drop any existing data in the postgis database/schema prior to restore. Enabled by default.
```--clean_django_db``` - Will clean the majority the existing fixtures in Django. Disabled by default.
