### PR TITLE
Fix for thumbnail generation + ol3

### DIFF
--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -18,6 +18,7 @@
 #
 #########################################################################
 
+from base64 import b64decode
 import math
 import logging
 from guardian.shortcuts import get_perms
@@ -978,7 +979,12 @@ def map_thumbnail(request, mapid):
     if request.method == 'POST':
         map_obj = _resolve_map(request, mapid)
         try:
-            image = _render_thumbnail(request.body)
+            # Base64 PNG data uploaded from the client!
+            if(request.body[0:22] == 'data:image/png;base64,'):
+                image = b64decode(request.body[22:])
+            # try the old way.
+            else:
+                image = _render_thumbnail(request.body)
 
             if not image:
                 return

--- a/geonode/static/geonode/js/utils/thumbnail.js
+++ b/geonode/static/geonode/js/utils/thumbnail.js
@@ -1,4 +1,4 @@
-var createMapThumbnail = function(obj_id) {
+var ol2_createMapThumbnail = function(obj_id) {
     var xmap = $('.olMapViewport');
     height = xmap.height();
     width = xmap.width();
@@ -31,4 +31,63 @@ var createMapThumbnail = function(obj_id) {
         }
     });
     return true;
+};
+
+/*
+ * Uses the features of Canvas to generate a thumbnail and
+ * upload it to the server.
+ */
+var ol3_createMapThumbnail = function() {
+    var canvas = $('.ol-viewport canvas');
+
+    // first, calculate the center 'thumbnail'
+    //   of the image.
+    var thumb_w = 240, thumb_h = 180;
+    var w = canvas.width(), h = canvas.height();
+    var c_x = w/2, c_y = h/2;
+    var x0 = c_x - thumb_w/2;
+    var y0 = c_y - thumb_h/2;
+
+    // then get the thumbnail from the image itself.
+    var clip = canvas[0].getContext('2d').getImageData(x0,y0,thumb_w,thumb_h);
+
+    // create a temporary canvas for the 
+    //  new thumbnail.
+    var thumb_canvas = $('<canvas>').appendTo('body');
+    thumb_canvas[0].width = thumb_w;
+    thumb_canvas[0].height = thumb_h;
+    thumb_canvas[0].getContext('2d').putImageData(clip,0,0);
+
+    // get the PNG for saving...
+    var png_data = thumb_canvas[0].toDataURL('image/png');
+
+    // and remove the element from the DOM.
+    thumb_canvas.remove();
+
+    // now, determine the URL and upload the thumbnail.
+    var url = window.location.pathname.replace('/view', '');
+    if (typeof obj_id != 'undefined' && url.indexOf('new')){
+        url = url.replace('new', obj_id);
+    }
+    url+= '/thumbnail';
+
+    $.ajax({
+        type: "POST",
+        url: url,
+        data: png_data,
+        success: function(data, status, jqXHR) {
+            return true;
+        }
+    });
+    return true;
+}
+
+var createMapThumbnail = function(obj_id) {
+    // when ol-viewport is found, assume OpenLayers 3+
+    if($('.ol-viewport').length > 0) {
+        ol3_createMapThumbnail();
+    } else {
+        // default to OpenLayers 2.
+        ol2_createMapThumbnail(obj_id);
+    }
 };


### PR DESCRIPTION
1. views.py has been updated with two functionalities:
 a. It now accepts the upload of a base64 encoded PNG as a thumbnail.
    This is converted to a PNG in memory and saved.
 b. It will return the URL of the thumbnail if there is one specified.
    This was very handy for debugging the generation of thumbnails.

2. thumbnail.js now properly recognizes when there is a OL3-style
   <canvas> and uses that to grab a thumbnail.  The OL3-style thumbnail
   generation will parse the PNG data and send it to the server. The PNG
   data is then handled appropriately by the changed described in part 1.

### Related Issues

NODE-780