### PR TITLE
Remove thumbnail_url from the metadata editing.

### DIFF
--- a/geonode/base/forms.py
+++ b/geonode/base/forms.py
@@ -189,5 +189,6 @@ class ResourceBaseForm(TranslationModelForm):
             'thumbnail',
             'charset',
             'rating',
-            'detail_url'
+            'detail_url',
+            'thumbnail_url',
             )


### PR DESCRIPTION
Removed erroneous thumbnail url editing from the metadata
editing screen.

Like detail_url, thumbnail_url is really not intended to be editable.