### PR TITLE
Added additional "include_create_map" flag.

### DIFF
--- a/geonode/templates/search/_search_content.html
+++ b/geonode/templates/search/_search_content.html
@@ -11,7 +11,7 @@
             <button type="button" class="btn btn-default" ng-disabled="!cart.getCart().items.length" data-toggle="modal" data-target="#_bulk_permissions">{% trans "Set permissions" %}</button>
           </div>
           {% endif %}
-          {% if facet_type == 'layers' %}
+          {% if facet_type == 'layers' or include_create_map == 'true' %}
           <div class="btn-group" role="group">
             <button type="button" class="btn btn-default" ng-disabled="!cart.getCart().items.length" ng-click="newMap()">{% trans "Create a Map" %}</button>
           </div>


### PR DESCRIPTION
Added a new flag in the template that allows the 'Create a Map'
button to be shown even when layers are not the only facet being
displayed.

This is specifically useful for the new "Search" screen that can feature multiple facets. 

