### PR TITLE
Fix for "overrunning" the extent filter map.

### DIFF
--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -614,6 +614,9 @@
           map = leafletData.getMap('filter-map');
 
       map.then(function(map){
+        /* prevent the user from wrapping around the world. */
+        map.setMaxBounds([[-180, -90], [180, 90]]);
+
         map.on('moveend', function(){
           $scope.query['extent'] = map.getBounds().toBBoxString();
           query_api($scope.query);


### PR DESCRIPTION
Added a MaxBounds to the leaflet map. This prevents the user from making invalid extent filters.

Refs: NODE-389