### PR TITLE
Fix sticky extent filter in searches

### DIFF
--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -625,12 +625,17 @@
     
       var showMap = false;
       $('#_extent_filter').click(function(evt) {
+        console.log('clicked extent header');
      	  showMap = !showMap
         if (showMap){
           leafletData.getMap().then(function(map) {
             map.invalidateSize();
           });
-        } 
+        } else {
+            /* clear the extent filter when the map is hidden */
+            delete $scope.query['extent'];
+            query_api($scope.query);
+        }
       });
     }
   });

--- a/geonode/static/geonode/js/search/search.js
+++ b/geonode/static/geonode/js/search/search.js
@@ -625,8 +625,7 @@
     
       var showMap = false;
       $('#_extent_filter').click(function(evt) {
-        console.log('clicked extent header');
-     	  showMap = !showMap
+     	showMap = !showMap
         if (showMap){
           leafletData.getMap().then(function(map) {
             map.invalidateSize();


### PR DESCRIPTION
The extent was not clearing when the extent filter was closed.

This updates the code to remove 'extent' from the query when the panel is shut.