### PR TITLE
Updatelayers and Geofence permissions

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -507,18 +507,16 @@ def gs_slurp(
                 raise Exception(
                     'Failed to process %s' %
                     resource.name.encode('utf-8'), e), None, sys.exc_info()[2]
-        else:
-            if created:
-                if not permissions:
-                    layer.set_default_permissions()
-                else:
-                    layer.set_permissions(permissions)
 
-                status = 'created'
-                output['stats']['created'] += 1
-            else:
-                status = 'updated'
-                output['stats']['updated'] += 1
+        if created:
+            if permissions:
+                layer.set_permissions(permissions)
+
+            status = 'created'
+            output['stats']['created'] += 1
+        else:
+            status = 'updated'
+            output['stats']['updated'] += 1
 
         msg = "[%s] Layer %s (%d/%d)" % (status, name, i + 1, number)
         info = {'name': name, 'status': status}
@@ -579,18 +577,16 @@ def gs_slurp(
                 raise Exception(
                     'Failed to process %s' %
                     lg.name.encode('utf-8'), e), None, sys.exc_info()[2]
-        else:
-            if created:
-                if not permissions:
-                    layer.set_default_permissions()
-                else:
-                    layer.set_permissions(permissions)
 
-                status = 'created'
-                output['stats']['created'] += 1
-            else:
-                status = 'updated'
-                output['stats']['updated'] += 1
+        if created:
+            if permissions:
+                layer.set_permissions(permissions)
+
+            status = 'created'
+            output['stats']['created'] += 1
+        else:
+            status = 'updated'
+            output['stats']['updated'] += 1
 
         msg = "[%s] Layer Group %s (%d/%d)" % (status, name, i + 1, lg_count)
         info = {'name': name, 'status': status}


### PR DESCRIPTION
- Removes duplicate ```set_default_permissions``` from update layers. Geonode will already set the default permissions on layer creation.

- Geofence will now not create rules for Anonymous user/group. This was not providing any access control. Instead, when anonymous view/download are enabled, geonode is creating a rule in geofence making the layer public. This hasn't changed, and unauthenticated WFS-T requests are still possible.

- Owner of a layer now always gets full access on a layer in geofence.

- Workspace in Geofence rules is now retrieved from layer, instead of being hard coded.
