### PR TITLE
Remove clean_username

### DIFF
--- a/geonode/people/forms.py
+++ b/geonode/people/forms.py
@@ -37,19 +37,6 @@ class ProfileCreationForm(UserCreationForm):
         model = Profile
         fields = ("username",)
 
-    def clean_username(self):
-        # Since User.username is unique, this check is redundant,
-        # but it sets a nicer error message than the ORM. See #13147.
-        username = self.cleaned_data["username"]
-        try:
-            Profile.objects.get(username=username)
-        except Profile.DoesNotExist:
-            return username
-        raise forms.ValidationError(
-            self.error_messages['duplicate_username'],
-            code='duplicate_username',
-        )
-
 
 class ProfileChangeForm(UserChangeForm):
 


### PR DESCRIPTION
This removes the clean_username method.
When adding an account with an existing username this method will raise a 500, instead of just warning the user the account/username already exist.

Users will now see the error specified din the migration:
https://github.com/boundlessgeo/geonode/blob/exchange/1.2.0/geonode/people/migrations/24_initial.py#L26