### PR TITLE
Skip default style when doesn't exist 

### DIFF
--- a/geonode/geoserver/helpers.py
+++ b/geonode/geoserver/helpers.py
@@ -830,9 +830,10 @@ def set_styles(layer, gs_catalog):
     style_set = []
     gs_layer = gs_catalog.get_layer(layer.name)
     default_style = gs_layer.default_style
-    layer.default_style = save_style(default_style)
-    # FIXME: This should remove styles that are no longer valid
-    style_set.append(layer.default_style)
+    if default_style:
+        layer.default_style = save_style(default_style)
+        # FIXME: This should remove styles that are no longer valid
+        style_set.append(layer.default_style)
 
     alt_styles = gs_layer.styles
 


### PR DESCRIPTION
Currently adding layers from a WMS store may fail.
This skips attempting setting a null style, which will allow WMS layers to be added to geonode.