### PR TITLE
Add support for standalone Geofence

### DIFF
--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -394,8 +394,15 @@ def remove_object_permissions(instance):
                 key = 'RuleList'
                 sub_key = 'rule'
 
+            # There are plenty of differences between the standalone and integrated versions of. Try dealing with them.
             if gs_rules_dict[key]:
-                for rule in gs_rules_dict[key][sub_key]:
+                if sub_key in gs_rules_dict[key].keys():
+                    rules = gs_rules_dict[key][sub_key]
+                else:
+                    rules = []
+                if not isinstance(rules, list):
+                    rules = [rules]
+                for rule in rules:
                     if 'layer' in rule.keys() and rule['layer'] == resource.layer.name:
                         if '@id' in rule.keys():
                             delete_geofence_rule(rule['@id'])

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -20,12 +20,11 @@
 import logging
 import traceback
 import requests
-
-from requests.auth import HTTPBasicAuth
+from urlparse import urlparse, parse_qsl
+from requests.packages.urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 from urllib import urlencode
-
 from django.contrib.auth import get_user_model
-
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import login
 from django.contrib.auth.models import Group, Permission
@@ -37,12 +36,12 @@ try:
     geofence_url = settings.GEOFENCE['url'].strip('/')
 except AttributeError:
     geofence_url = "{}/geofence".format(settings.OGC_SERVER['default']['LOCATION'].strip('/'))
-    
+
 try:
     geofence_username = settings.GEOFENCE['username']
 except AttributeError:
     geofence_username = settings.OGC_SERVER['default']['USER']
-    
+
 try:
     geofence_password = settings.GEOFENCE['password']
 except AttributeError:
@@ -65,6 +64,45 @@ LAYER_ADMIN_PERMISSIONS = [
     'change_layer_data',
     'change_layer_style'
 ]
+
+http_client = requests.session()
+http_client.verify = True
+parsed_url = urlparse(geofence_url)
+retry = Retry(
+    total=4,
+    status=4,
+    backoff_factor=0.9,
+    status_forcelist=[502, 503, 504],
+    method_whitelist=set(['HEAD', 'TRACE', 'GET', 'PUT', 'POST', 'OPTIONS', 'DELETE'])
+)
+
+http_client.mount("{}://".format(parsed_url.scheme), HTTPAdapter(max_retries=retry))
+
+
+def http_request(self, url, data=None, method='get', headers={}, access_token=None):
+    req_method = getattr(http_client, method.lower())
+    resp = None
+
+    if access_token:
+        headers['Authorization'] = "Bearer {}".format(access_token)
+        parsed_url = urlparse(url)
+        params = parse_qsl(parsed_url.query.strip())
+        params.append(('access_token', access_token))
+        params = urlencode(params)
+        url = "{proto}://{address}{path}?{params}".format(proto=parsed_url.scheme, address=parsed_url.netloc,
+                                                          path=parsed_url.path, params=params)
+
+        try:
+            resp = req_method(url, headers=headers, data=data)
+        except:
+            logger.debug(traceback.format_exc())
+    else:
+        try:
+            resp = req_method(url, headers=headers, data=data, auth=(geofence_username, geofence_password))
+        except:
+            logger.debug(traceback.format_exc())
+
+    return resp
 
 
 def get_users_with_perms(obj):
@@ -289,17 +327,17 @@ def set_geofence_user(instance, username, view_perms=False, download_perms=False
 
         if view_perms and download_perms:
             data = "<Rule>{}</Rule>".format(payload)
-            create_geofence_rule(rule = data)
+            create_geofence_rule(rule=data)
         else:
             if view_perms:
                 for service in ['WMS', 'GWC']:
-                  data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
-                  create_geofence_rule(rule = data)
+                    data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
+                    create_geofence_rule(rule=data)
 
             if download_perms:
                 for service in ['WCS', 'WFS', 'WPS']:
-                  data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
-                  create_geofence_rule(rule = data)
+                    data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
+                    create_geofence_rule(rule=data)
 
 
 def set_geofence_group(instance, groupname, view_perms=False, download_perms=False):
@@ -313,17 +351,17 @@ def set_geofence_group(instance, groupname, view_perms=False, download_perms=Fal
 
         if view_perms and download_perms:
             data = "<Rule>{}</Rule>".format(payload)
-            create_geofence_rule(rule = data)
+            create_geofence_rule(rule=data)
         else:
             if view_perms:
                 for service in ['WMS', 'GWC']:
-                  data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
-                  create_geofence_rule(rule = data)
+                    data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
+                    create_geofence_rule(rule=data)
 
             if download_perms:
                 for service in ['WCS', 'WFS', 'WPS']:
-                  data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
-                  create_geofence_rule(rule = data)
+                    data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
+                    create_geofence_rule(rule=data)
 
 
 def set_owner_permissions(resource):
@@ -390,11 +428,11 @@ def autologin(sender, **kwargs):
     user.backend = 'django.contrib.auth.backends.ModelBackend'
     # This login function does not need password.
     login(request, user)
-
 # FIXME(Ariel): Replace this signal with the one from django-user-accounts
 # user_activated.connect(autologin)
 
-def create_geofence_rule(rule = None):
+
+def create_geofence_rule(rule=None):
     # Create GeoFence User's specific Access Limits
     """
     curl -X POST -u admin:geoserver -H "Content-Type: text/xml" -d \
@@ -405,74 +443,55 @@ def create_geofence_rule(rule = None):
 
     if rule:
         rules_url = "{}/rest/rules".format(geofence_url)
-        user = geofence_username
-        passwd = geofence_password
         headers = {'Content-type': 'application/xml'}
         geofence_rule = None
 
-        try:
-            resp = requests.post(
-                rules_url,
-                headers=headers,
-                data=rule,
-                auth=(user, passwd)
-            )
-        except:
-            tb = traceback.format_exc()
-            logger.debug(tb)
+        resp = http_request(
+            rules_url,
+            method='post',
+            headers=headers,
+            data=rule
+        )
 
         if resp.status_code in (200, 201):
             rule_id = resp.content
             geofence_rule = get_geofence_rule_by_id(id=rule_id)
             if not geofence_rule:
-                logger.error("GeoFence created rule {}, however rule can't be found in GeoFence's database".format(rule_id))
+                logger.error("GeoFence created rule {}, however rule can not be found in GeoFence".format(rule_id))
         else:
-            msg = "Failed to add GeoServer/GeoFence rule {}".format(rule)
-            logger.error(msg)
+            logger.error("Failed to add GeoFence rule {}".format(rule))
 
         return geofence_rule
 
 
-def get_geofence_rule_by_id(id, output_type = 'xml'):
+def get_geofence_rule_by_id(id, output_type='xml'):
     """
     Get a single GeoFence rule by it's ID, either in json or xml format
     """
 
     rules_url = "{}/rest/rules".format(geofence_url)
-    user = geofence_username
-    passwd = geofence_password
     output_type = output_type.lower().strip('.')
 
     if id:
         id_url = "{}/id/{}.{}".format(rules_url, id, output_type)
-        try:
-            resp = requests.get(
-                id_url,
-                auth=(user, passwd)
-            )
+        resp = http_request(id_url)
 
-            if resp.status_code == 200:
-                if output_type == 'json':
-                    return resp.json()
-                else:
-                    return resp.content
+        if resp.status_code == 200:
+            if output_type == 'json':
+                return resp.json()
             else:
-                logger.warning("Couldn't find rule {} in GeoFence".format(id))
-        except:
-            tb = traceback.format_exc()
-            logger.debug(tb)
-
-        return None
+                return resp.content
+        else:
+            logger.warning("Could not find rule {} in GeoFence".format(id))
+    return None
 
 
-def get_geofence_rules(workspace = None, layer = None, output_type = 'xml'):
+def get_geofence_rules(workspace=None, layer=None, output_type='xml'):
     """
     Get GeoFence rules, either in json or xml format. May provide a workspace/layername filter
     """
 
     rules_url = "{}/rest/rules".format(geofence_url)
-    user = geofence_username
-    passwd = geofence_password
     output_type = output_type.lower().strip('.')
     rules_url = "{}.{}".format(rules_url, output_type)
     params = {}
@@ -485,22 +504,15 @@ def get_geofence_rules(workspace = None, layer = None, output_type = 'xml'):
     encode_params = urlencode(params)
     filter_url = "{}?{}".format(rules_url, encode_params)
 
-    try:
-        resp = requests.get(
-            filter_url,
-            auth=(user, passwd)
-        )
+    resp = http_request(filter_url)
 
-        if resp.status_code == 200:
-            if output_type == 'json':
-                return resp.json()
-            else:
-                return resp.content
+    if resp.status_code == 200:
+        if output_type == 'json':
+            return resp.json()
         else:
-            logger.warning("Couldn't get rule from GeoFence")
-    except:
-        tb = traceback.format_exc()
-        logger.debug(tb)
+            return resp.content
+    else:
+        logger.warning("Could not get rule from GeoFence")
     return None
 
 
@@ -509,22 +521,15 @@ def delete_geofence_rule(id):
     Delete a GeoFence rule by rule ID
     """
     rule_url = "{}/rest/rules/id/{}".format(geofence_url, id)
-    user = geofence_username
-    passwd = geofence_password
     headers = {'Content-type': 'application/json'}
+    resp = http_request(
+        rule_url,
+        method='delete',
+        headers=headers
+    )
 
-    try:
-        resp = requests.delete(
-            rule_url,
-            headers=headers,
-            auth=(user, passwd)
-        )
-
-        if resp.status_code == 200:
-            return True
-        else:
-            logger.warning("Couldn't delete rule from GeoFence {}".format(id))
-    except:
-        tb = traceback.format_exc()
-        logger.debug(tb)
+    if resp.status_code == 200:
+        return True
+    else:
+        logger.warning("Could not delete rule from GeoFence {}".format(id))
     return None

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -33,6 +33,20 @@ from django.conf import settings
 from guardian.utils import get_user_obj_perms_model
 from guardian.shortcuts import assign_perm, get_groups_with_perms
 
+try:
+    geofence_url = settings.GEOFENCE['url'].strip('/')
+except AttributeError:
+    geofence_url = "{}/geofence".format(settings.OGC_SERVER['default']['LOCATION'].strip('/'))
+    
+try:
+    geofence_username = settings.GEOFENCE['username']
+except AttributeError:
+    geofence_username = settings.OGC_SERVER['default']['USER']
+    
+try:
+    geofence_password = settings.GEOFENCE['password']
+except AttributeError:
+    geofence_password = settings.OGC_SERVER['default']['PASSWORD']
 
 logger = logging.getLogger("geonode.security.models")
 
@@ -259,9 +273,8 @@ def set_geofence_all(instance):
         http://<host>:<port>/geoserver/geofence/rest/rules
         """
 
-        payload = "<Rule><workspace>{}</workspace><layer>".format(resource.layer.workspace)
-        payload = payload + resource.layer.name
-        payload = payload + "</layer><access>ALLOW</access></Rule>"
+        payload = "<Rule><workspace>{}</workspace>".format(resource.layer.workspace)
+        payload += "<layer>{}</layer><access>ALLOW</access></Rule>".format(resource.layer.name)
         create_geofence_rule(payload)
 
 
@@ -271,8 +284,8 @@ def set_geofence_user(instance, username, view_perms=False, download_perms=False
 
     if hasattr(resource, "layer"):
         payload = "<userName>{}</userName>".format(username)
-        payload = payload + "<workspace>{}</workspace>".format(resource.layer.workspace)
-        payload = payload + "<layer>{}</layer><access>ALLOW</access>".format(resource.layer.name)
+        payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
+        payload += "<layer>{}</layer><access>ALLOW</access>".format(resource.layer.name)
 
         if view_perms and download_perms:
             data = "<Rule>{}</Rule>".format(payload)
@@ -294,9 +307,9 @@ def set_geofence_group(instance, groupname, view_perms=False, download_perms=Fal
     resource = instance.get_self_resource()
 
     if hasattr(resource, "layer"):
-        payload = "<roleName>ROLE_" + groupname.upper()
-        payload = payload + "</roleName><workspace>{}</workspace><layer>".format(resource.layer.workspace)
-        payload = payload + resource.layer.name + "</layer><access>ALLOW</access>"
+        payload = "<roleName>ROLE_{}</roleName>".format(groupname.upper())
+        payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
+        payload += "<layer>{}</layer><access>ALLOW</access>".format(resource.layer.name)
 
         if view_perms and download_perms:
             data = "<Rule>{}</Rule>".format(payload)
@@ -336,47 +349,35 @@ def remove_object_permissions(instance):
     resource = instance.get_self_resource()
 
     if hasattr(resource, "layer"):
+        gs_rules = get_geofence_rules(workspace=resource.layer.workspace, layer=resource.layer.name, output_type='json')
+        if gs_rules and gs_rules['rules']:
+            for r in gs_rules['rules']:
+                if r['layer'] and r['layer'] == resource.layer.name:
+                    delete_geofence_rule(r['id'])
+
         try:
-            # Scan GeoFence Rules associated to the Layer
-            """
-            curl -u admin:geoserver
-            http://<host>:<port>/geoserver/geofence/rest/rules.json?workspace=geonode&layer={layer}
-            """
-            url = settings.OGC_SERVER['default']['LOCATION']
-            user = settings.OGC_SERVER['default']['USER']
-            passwd = settings.OGC_SERVER['default']['PASSWORD']
-            headers = {'Content-type': 'application/json'}
-
-            gs_rules = get_geofence_rules(workspace=resource.layer.workspace, layer=resource.layer.name, output_type='json')
-            r_ids = []
-            if gs_rules and gs_rules['rules']:
-                for r in gs_rules['rules']:
-                    if r['layer'] and r['layer'] == resource.layer.name:
-                        r_ids.append(r['id'])
-
-            # Delete GeoFence Rules associated to the Layer
-            # curl -X DELETE -u admin:geoserver http://<host>:<port>/geoserver/geofence/rest/rules/id/{r_id}
-            for i, r_id in enumerate(r_ids):
-                r = requests.delete(url + 'geofence/rest/rules/id/' + str(r_id),
-                                    headers=headers,
-                                    auth=HTTPBasicAuth(user, passwd))
-                if (r.status_code != 200):
-                    msg = "Could not DELETE GeoServer Rule for Layer "
-                    msg = msg + str(resource.layer.name)
-                    logger.warning(msg)
-
             UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource.layer),
                                                 object_pk=instance.id).delete()
+        except:
+            logger.debug(traceback.format_exc())
+
+        try:
             GroupObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource.layer),
                                                  object_pk=instance.id).delete()
         except:
-            tb = traceback.format_exc()
-            logger.debug(tb)
+            logger.debug(traceback.format_exc())
 
-    UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
-                                        object_pk=instance.id).delete()
-    GroupObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
-                                         object_pk=instance.id).delete()
+        try:
+            UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
+                                                object_pk=instance.id).delete()
+        except:
+            logger.debug(traceback.format_exc())
+
+        try:
+            GroupObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
+                                                 object_pk=instance.id).delete()
+        except:
+            logger.debug(traceback.format_exc())
 
 
 # Logic to login a user automatically when it has successfully
@@ -403,15 +404,14 @@ def create_geofence_rule(rule = None):
     """
 
     if rule:
-        rules_url = "{}/geofence/rest/rules".format(settings.OGC_SERVER['default']['LOCATION'].strip('/'))
-        user = settings.OGC_SERVER['default']['USER']
-        passwd = settings.OGC_SERVER['default']['PASSWORD']
+        rules_url = "{}/rest/rules".format(geofence_url)
+        user = geofence_username
+        passwd = geofence_password
         headers = {'Content-type': 'application/xml'}
-
         geofence_rule = None
 
         try:
-            r = requests.post(
+            resp = requests.post(
                 rules_url,
                 headers=headers,
                 data=rule,
@@ -421,8 +421,8 @@ def create_geofence_rule(rule = None):
             tb = traceback.format_exc()
             logger.debug(tb)
 
-        if r.status_code in (200, 201):
-            rule_id = r.content
+        if resp.status_code in (200, 201):
+            rule_id = resp.content
             geofence_rule = get_geofence_rule_by_id(id=rule_id)
             if not geofence_rule:
                 logger.error("GeoFence created rule {}, however rule can't be found in GeoFence's database".format(rule_id))
@@ -438,24 +438,24 @@ def get_geofence_rule_by_id(id, output_type = 'xml'):
     Get a single GeoFence rule by it's ID, either in json or xml format
     """
 
-    rules_url = "{}/geofence/rest/rules".format(settings.OGC_SERVER['default']['LOCATION'].strip('/'))
-    user = settings.OGC_SERVER['default']['USER']
-    passwd = settings.OGC_SERVER['default']['PASSWORD']
+    rules_url = "{}/rest/rules".format(geofence_url)
+    user = geofence_username
+    passwd = geofence_password
     output_type = output_type.lower().strip('.')
 
     if id:
         id_url = "{}/id/{}.{}".format(rules_url, id, output_type)
         try:
-            r = requests.get(
+            resp = requests.get(
                 id_url,
                 auth=(user, passwd)
             )
 
-            if r.status_code == 200:
+            if resp.status_code == 200:
                 if output_type == 'json':
-                    return r.json()
+                    return resp.json()
                 else:
-                    return r.content
+                    return resp.content
             else:
                 logger.warning("Couldn't find rule {} in GeoFence".format(id))
         except:
@@ -470,13 +470,13 @@ def get_geofence_rules(workspace = None, layer = None, output_type = 'xml'):
     Get GeoFence rules, either in json or xml format. May provide a workspace/layername filter
     """
 
-    rules_url = "{}/geofence/rest/rules".format(settings.OGC_SERVER['default']['LOCATION'].strip('/'))
-    user = settings.OGC_SERVER['default']['USER']
-    passwd = settings.OGC_SERVER['default']['PASSWORD']
+    rules_url = "{}/rest/rules".format(geofence_url)
+    user = geofence_username
+    passwd = geofence_password
     output_type = output_type.lower().strip('.')
     rules_url = "{}.{}".format(rules_url, output_type)
-
     params = {}
+
     if workspace:
         params['workspace'] = workspace
     if layer:
@@ -486,18 +486,44 @@ def get_geofence_rules(workspace = None, layer = None, output_type = 'xml'):
     filter_url = "{}?{}".format(rules_url, encode_params)
 
     try:
-        r = requests.get(
+        resp = requests.get(
             filter_url,
             auth=(user, passwd)
         )
 
-        if r.status_code == 200:
+        if resp.status_code == 200:
             if output_type == 'json':
-                return r.json()
+                return resp.json()
             else:
-                return r.content
+                return resp.content
         else:
             logger.warning("Couldn't get rule from GeoFence")
+    except:
+        tb = traceback.format_exc()
+        logger.debug(tb)
+    return None
+
+
+def delete_geofence_rule(id):
+    """
+    Delete a GeoFence rule by rule ID
+    """
+    rule_url = "{}/rest/rules/id/{}".format(geofence_url, id)
+    user = geofence_username
+    passwd = geofence_password
+    headers = {'Content-type': 'application/json'}
+
+    try:
+        resp = requests.delete(
+            rule_url,
+            headers=headers,
+            auth=(user, passwd)
+        )
+
+        if resp.status_code == 200:
+            return True
+        else:
+            logger.warning("Couldn't delete rule from GeoFence {}".format(id))
     except:
         tb = traceback.format_exc()
         logger.debug(tb)

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -279,7 +279,7 @@ class PermissionLevelMixin(object):
                 has_edit_perms = ('change_layer_data' in perms)
                 if user.username.lower() != 'anonymoususer':
                     # Anonymous access is already given above
-                    set_data_user_acl(self, str(user), view_perms=has_view_perms, edit_perms=has_edit_perms)
+                    set_data_acl(self, str(user), view_perms=has_view_perms, edit_perms=has_edit_perms)
 
         if 'groups' in perm_spec:
             for group, perms in perm_spec['groups'].items():
@@ -296,7 +296,7 @@ class PermissionLevelMixin(object):
                 has_edit_perms = ('change_layer_data' in perms)
                 if group.name.lower() != 'anonymous':
                     # Anonymous access is already given above
-                    set_data_group_acl(self, str(group), view_perms=has_view_perms, edit_perms=has_edit_perms)
+                    set_data_acl(self, str(group), view_perms=has_view_perms, edit_perms=has_edit_perms, type='group')
 
         # default permissions for resource owner
         set_owner_permissions(self)
@@ -318,55 +318,28 @@ def set_data_public_access(instance):
         create_geofence_rule(payload)
 
 
-def set_data_user_acl(instance, username, view_perms=False, edit_perms=False):
+def set_data_acl(instance, name, view_perms=False, edit_perms=False, type='user'):
     """assign access permissions to a user account"""
     resource = instance.get_self_resource()
 
     if hasattr(resource, "layer"):
         if internal_geofence:
-            payload = "<Rule><userName>{}</userName>".format(username)
+            if type == 'user':
+                payload = "<Rule><userName>{}</userName>".format(name)
+            elif type == 'group':
+                payload = "<Rule><roleName>ROLE_{}</roleName>".format(name.upper())
             payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
             payload += "<layer>{}</layer><access>ALLOW</access>".format(resource.layer.name)
             rule_end = "</Rule>"
         else:
             payload = "<rule grant='ALLOW'><position value='0' position='offsetFromTop'/>"
             payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
-            payload += "<layer>{}</layer><username>{}</username>".format(resource.layer.name, username)
-            rule_end = "</rule>"
+            payload += "<layer>{}</layer>".format(resource.layer.name)
 
-        if view_perms and edit_perms:
-            data = "{}{}".format(payload, rule_end)
-            create_geofence_rule(rule=data)
-        else:
-            if view_perms:
-                for service in ['WMS', 'GWC', 'WCS']:
-                    data = "{}<service>{}</service>{}".format(payload, service, rule_end)
-                    create_geofence_rule(rule=data)
-
-                for type in ['GETCAPABILITIES', 'GETFEATURETYPE', 'DESCRIBEFEATURETYPE', 'GETFEATURE', 'GETGMLOBJECT']:
-                    data = "{}<service>WFS</service><request>{}</request>{}".format(payload, type, rule_end)
-                    create_geofence_rule(rule=data)
-
-            if edit_perms:
-                for service in ['WMS', 'GWC', 'WCS', 'WFS', 'WPS']:
-                    data = "{}<service>{}</service>{}".format(payload, service, rule_end)
-                    create_geofence_rule(rule=data)
-
-
-def set_data_group_acl(instance, groupname, view_perms=False, edit_perms=False):
-    """assign access permissions to owner group"""
-    resource = instance.get_self_resource()
-
-    if hasattr(resource, "layer"):
-        if internal_geofence:
-            payload = "<Rule><roleName>ROLE_{}</roleName>".format(groupname.upper())
-            payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
-            payload += "<layer>{}</layer><access>ALLOW</access>".format(resource.layer.name)
-            rule_end = "</Rule>"
-        else:
-            payload = "<rule grant='ALLOW'><position value='0' position='offsetFromTop'/>"
-            payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
-            payload += "<layer>{}</layer><rolename>ROLE_{}</rolename>".format(resource.layer.name, groupname.upper())
+            if type == 'user':
+                payload += "<username>{}</username>".format(name)
+            elif type == 'group':
+                payload += "<rolename>ROLE_{}</rolename>".format(name.upper())
             rule_end = "</rule>"
 
         if view_perms and edit_perms:
@@ -397,7 +370,7 @@ def set_owner_permissions(resource):
                 assign_perm(perm, resource.owner, resource.layer)
 
         # Set the GeoFence Owner Rule
-        set_data_user_acl(resource, str(resource.owner), view_perms=True, edit_perms=True)
+        set_data_acl(resource, str(resource.owner), view_perms=True, edit_perms=True)
 
         for perm in ADMIN_PERMISSIONS:
             assign_perm(perm, resource.owner, resource.get_self_resource())
@@ -424,7 +397,10 @@ def remove_object_permissions(instance):
             if gs_rules_dict[key]:
                 for rule in gs_rules_dict[key][sub_key]:
                     if 'layer' in rule.keys() and rule['layer'] == resource.layer.name:
-                        delete_geofence_rule(rule['id'])
+                        if '@id' in rule.keys():
+                            delete_geofence_rule(rule['@id'])
+                        else:
+                            delete_geofence_rule(rule['id'])
 
         try:
             UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource.layer),

--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -31,6 +31,7 @@ from django.contrib.auth.models import Group, Permission
 from django.conf import settings
 from guardian.utils import get_user_obj_perms_model
 from guardian.shortcuts import assign_perm, get_groups_with_perms
+from xmltodict import parse
 
 try:
     geofence_url = settings.GEOFENCE['url'].strip('/')
@@ -47,6 +48,7 @@ try:
 except AttributeError:
     geofence_password = settings.OGC_SERVER['default']['PASSWORD']
 
+internal_geofence = settings.OGC_SERVER['default']['LOCATION'] in geofence_url
 logger = logging.getLogger("geonode.security.models")
 
 
@@ -79,7 +81,7 @@ retry = Retry(
 http_client.mount("{}://".format(parsed_url.scheme), HTTPAdapter(max_retries=retry))
 
 
-def http_request(self, url, data=None, method='get', headers={}, access_token=None):
+def http_request(url, data=None, method='get', headers={}, access_token=None):
     req_method = getattr(http_client, method.lower())
     resp = None
 
@@ -211,7 +213,7 @@ class PermissionLevelMixin(object):
 
         # Give public access to all Geoserver layers
         if set_geofence_permissions:
-            set_geofence_all(self)
+            set_data_public_access(self)
 
         # default permissions for resource owner
         set_owner_permissions(self)
@@ -258,7 +260,7 @@ class PermissionLevelMixin(object):
                 public_access = True
         if public_access:
             # if we allow public access to the layer, why also assign user specific permissions?
-            set_geofence_all(self)
+            set_data_public_access(self)
             # return
 
         # TODO refactor code here
@@ -274,10 +276,10 @@ class PermissionLevelMixin(object):
                         assign_perm(perm, user, self.get_self_resource())
                 # Set the GeoFence Owner Rules
                 has_view_perms = ('view_resourcebase' in perms)
-                has_download_perms = ('download_resourcebase' in perms)
+                has_edit_perms = ('change_layer_data' in perms)
                 if user.username.lower() != 'anonymoususer':
                     # Anonymous access is already given above
-                    set_geofence_user(self, str(user), view_perms=has_view_perms, download_perms=has_download_perms)
+                    set_data_user_acl(self, str(user), view_perms=has_view_perms, edit_perms=has_edit_perms)
 
         if 'groups' in perm_spec:
             for group, perms in perm_spec['groups'].items():
@@ -291,76 +293,98 @@ class PermissionLevelMixin(object):
                         assign_perm(perm, group, self.get_self_resource())
                 # Set the GeoFence Owner Rules
                 has_view_perms = ('view_resourcebase' in perms)
-                has_download_perms = ('download_resourcebase' in perms)
+                has_edit_perms = ('change_layer_data' in perms)
                 if group.name.lower() != 'anonymous':
                     # Anonymous access is already given above
-                    set_geofence_group(self, str(group), view_perms=has_view_perms, download_perms=has_download_perms)
+                    set_data_group_acl(self, str(group), view_perms=has_view_perms, edit_perms=has_edit_perms)
 
         # default permissions for resource owner
         set_owner_permissions(self)
 
 
-def set_geofence_all(instance):
+def set_data_public_access(instance):
     """This will provide unauthenticated access to all services on the layer, which includes WFS-T"""
     resource = instance.get_self_resource()
 
     if hasattr(resource, "layer"):
-        """
-        curl -X POST -u admin:geoserver -H "Content-Type: text/xml" -d \
-        "<Rule><workspace>geonode</workspace><layer>{layer}</layer><access>ALLOW</access></Rule>" \
-        http://<host>:<port>/geoserver/geofence/rest/rules
-        """
+        if internal_geofence:
+            payload = "<Rule><workspace>{}</workspace>".format(resource.layer.workspace)
+            payload += "<layer>{}</layer><access>ALLOW</access></Rule>".format(resource.layer.name)
+        else:
+            payload = "<rule grant='ALLOW'><position value='0' position='offsetFromTop'/>"
+            payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
+            payload += "<layer>{}</layer></rule>".format(resource.layer.name)
 
-        payload = "<Rule><workspace>{}</workspace>".format(resource.layer.workspace)
-        payload += "<layer>{}</layer><access>ALLOW</access></Rule>".format(resource.layer.name)
         create_geofence_rule(payload)
 
 
-def set_geofence_user(instance, username, view_perms=False, download_perms=False):
+def set_data_user_acl(instance, username, view_perms=False, edit_perms=False):
     """assign access permissions to a user account"""
     resource = instance.get_self_resource()
 
     if hasattr(resource, "layer"):
-        payload = "<userName>{}</userName>".format(username)
-        payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
-        payload += "<layer>{}</layer><access>ALLOW</access>".format(resource.layer.name)
+        if internal_geofence:
+            payload = "<Rule><userName>{}</userName>".format(username)
+            payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
+            payload += "<layer>{}</layer><access>ALLOW</access>".format(resource.layer.name)
+            rule_end = "</Rule>"
+        else:
+            payload = "<rule grant='ALLOW'><position value='0' position='offsetFromTop'/>"
+            payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
+            payload += "<layer>{}</layer><username>{}</username>".format(resource.layer.name, username)
+            rule_end = "</rule>"
 
-        if view_perms and download_perms:
-            data = "<Rule>{}</Rule>".format(payload)
+        if view_perms and edit_perms:
+            data = "{}{}".format(payload, rule_end)
             create_geofence_rule(rule=data)
         else:
             if view_perms:
-                for service in ['WMS', 'GWC']:
-                    data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
+                for service in ['WMS', 'GWC', 'WCS']:
+                    data = "{}<service>{}</service>{}".format(payload, service, rule_end)
                     create_geofence_rule(rule=data)
 
-            if download_perms:
-                for service in ['WCS', 'WFS', 'WPS']:
-                    data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
+                for type in ['GETCAPABILITIES', 'GETFEATURETYPE', 'DESCRIBEFEATURETYPE', 'GETFEATURE', 'GETGMLOBJECT']:
+                    data = "{}<service>WFS</service><request>{}</request>{}".format(payload, type, rule_end)
+                    create_geofence_rule(rule=data)
+
+            if edit_perms:
+                for service in ['WMS', 'GWC', 'WCS', 'WFS', 'WPS']:
+                    data = "{}<service>{}</service>{}".format(payload, service, rule_end)
                     create_geofence_rule(rule=data)
 
 
-def set_geofence_group(instance, groupname, view_perms=False, download_perms=False):
+def set_data_group_acl(instance, groupname, view_perms=False, edit_perms=False):
     """assign access permissions to owner group"""
     resource = instance.get_self_resource()
 
     if hasattr(resource, "layer"):
-        payload = "<roleName>ROLE_{}</roleName>".format(groupname.upper())
-        payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
-        payload += "<layer>{}</layer><access>ALLOW</access>".format(resource.layer.name)
+        if internal_geofence:
+            payload = "<Rule><roleName>ROLE_{}</roleName>".format(groupname.upper())
+            payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
+            payload += "<layer>{}</layer><access>ALLOW</access>".format(resource.layer.name)
+            rule_end = "</Rule>"
+        else:
+            payload = "<rule grant='ALLOW'><position value='0' position='offsetFromTop'/>"
+            payload += "<workspace>{}</workspace>".format(resource.layer.workspace)
+            payload += "<layer>{}</layer><rolename>ROLE_{}</rolename>".format(resource.layer.name, groupname.upper())
+            rule_end = "</rule>"
 
-        if view_perms and download_perms:
-            data = "<Rule>{}</Rule>".format(payload)
+        if view_perms and edit_perms:
+            data = "{}{}".format(payload, rule_end)
             create_geofence_rule(rule=data)
         else:
             if view_perms:
-                for service in ['WMS', 'GWC']:
-                    data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
+                for service in ['WMS', 'GWC', 'WCS']:
+                    data = "{}<service>{}</service>{}".format(payload, service, rule_end)
                     create_geofence_rule(rule=data)
 
-            if download_perms:
-                for service in ['WCS', 'WFS', 'WPS']:
-                    data = "<Rule>{}<service>{}</service></Rule>".format(payload, service)
+                for type in ['GETCAPABILITIES', 'GETFEATURETYPE', 'DESCRIBEFEATURETYPE', 'GETFEATURE', 'GETGMLOBJECT']:
+                    data = "{}<service>WFS</service><request>{}</request>{}".format(payload, type, rule_end)
+                    create_geofence_rule(rule=data)
+
+            if edit_perms:
+                for service in ['WMS', 'GWC', 'WCS', 'WFS', 'WPS']:
+                    data = "{}<service>{}</service>{}".format(payload, service, rule_end)
                     create_geofence_rule(rule=data)
 
 
@@ -373,7 +397,7 @@ def set_owner_permissions(resource):
                 assign_perm(perm, resource.owner, resource.layer)
 
         # Set the GeoFence Owner Rule
-        set_geofence_user(resource, str(resource.owner), view_perms=True, download_perms=True)
+        set_data_user_acl(resource, str(resource.owner), view_perms=True, edit_perms=True)
 
         for perm in ADMIN_PERMISSIONS:
             assign_perm(perm, resource.owner, resource.get_self_resource())
@@ -387,11 +411,20 @@ def remove_object_permissions(instance):
     resource = instance.get_self_resource()
 
     if hasattr(resource, "layer"):
-        gs_rules = get_geofence_rules(workspace=resource.layer.workspace, layer=resource.layer.name, output_type='json')
-        if gs_rules and gs_rules['rules']:
-            for r in gs_rules['rules']:
-                if r['layer'] and r['layer'] == resource.layer.name:
-                    delete_geofence_rule(r['id'])
+        gs_rules = get_geofence_rules(workspace=resource.layer.workspace, layer=resource.layer.name)
+        if gs_rules:
+            gs_rules_dict = parse(gs_rules)
+            if internal_geofence:
+                key = 'Rules'
+                sub_key = 'Rule'
+            else:
+                key = 'RuleList'
+                sub_key = 'rule'
+
+            if gs_rules_dict[key]:
+                for rule in gs_rules_dict[key][sub_key]:
+                    if 'layer' in rule.keys() and rule['layer'] == resource.layer.name:
+                        delete_geofence_rule(rule['id'])
 
         try:
             UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource.layer),
@@ -473,7 +506,10 @@ def get_geofence_rule_by_id(id, output_type='xml'):
     output_type = output_type.lower().strip('.')
 
     if id:
-        id_url = "{}/id/{}.{}".format(rules_url, id, output_type)
+        if internal_geofence:
+            id_url = "{}/id/{}.{}".format(rules_url, id, output_type)
+        else:
+            id_url = "{}/id/{}".format(rules_url, id)
         resp = http_request(id_url)
 
         if resp.status_code == 200:
@@ -493,7 +529,9 @@ def get_geofence_rules(workspace=None, layer=None, output_type='xml'):
 
     rules_url = "{}/rest/rules".format(geofence_url)
     output_type = output_type.lower().strip('.')
-    rules_url = "{}.{}".format(rules_url, output_type)
+    if internal_geofence:
+        rules_url = "{}.{}".format(rules_url, output_type)
+
     params = {}
 
     if workspace:


### PR DESCRIPTION
This makes it possible to use a standalone instead of depending on the geoserver integrated geofence.

**Functionality changes**
- Access control has changed a bit: To allow other users to edit the layer's data the account/group must be added via `Who can edit data for this layer?` in Geonode. If not, transactions will be blocked by Geofence.
- Only `Who can view it?` and `Who can edit data for this layer?` affect Geofence.

**Known issues standalone Geofence:**
- Openlayers preview in Geoserver will fail when using Geonode OAuth because Geofence will fail to parse the username.
- Configuring Geofence to use roles from Geoserver, or in Geonode case the roles that are retrieved via Authkey, will give unexpected results. All authenticated users may have access to all layers.
Workaround is creating users and roles in Geofence, however that hasn't been implemented in this PR in the hope it will be fixed in future Geofence versions.

 **Known issues integrated Geofence:**
- Rule/ACL insertion may fail, which will require the deletion of the last rule created
- Can't use Postgres backend 

**Implementation issues**
- Geonode will delete all layer specific geofence ACLs when permissions are saved instead of modifying the existing ones