### PR TITLE
GeoServer stores aren't created automatically. gsconfig now returns…

### DIFF
--- a/geonode/upload/utils.py
+++ b/geonode/upload/utils.py
@@ -45,6 +45,8 @@ def create_geoserver_db_featurestore(
             ds = cat.get_store(dsname)
         else:
             return None
+        if ds is None:
+            raise FailedRequestError
     except FailedRequestError:
         if store_type == 'geogig':
             if store_name is None and hasattr(


### PR DESCRIPTION
… None rather than raising an error, so upload utils needs to throw an error if response is None to capture this responsibility