### PR TITLE
Node 1216

### DIFF
--- a/geonode/documents/search_indexes.py
+++ b/geonode/documents/search_indexes.py
@@ -24,10 +24,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Avg
 from haystack import indexes
 from geonode.documents.models import Document
+import uuid
 
 
 class DocumentIndex(indexes.SearchIndex, indexes.Indexable):
-    id = indexes.IntegerField(model_attr='id')
+    id = indexes.IntegerField()
     abstract = indexes.CharField(model_attr="abstract", boost=1.5)
     category__gn_description = indexes.CharField(model_attr="category__gn_description", null=True)
     csw_type = indexes.CharField(model_attr="csw_type")
@@ -88,6 +89,10 @@ class DocumentIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return Document
+
+    def prepare_id(self, obj):
+        # this is awful I'm so sorry
+        return int(uuid.UUID(obj.uuid).time_low)
 
     def prepare_type(self, obj):
         return "document"

--- a/geonode/groups/search_indexes.py
+++ b/geonode/groups/search_indexes.py
@@ -43,7 +43,7 @@ class GroupIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_id(self, obj):
         # this is awful I'm so sorry
-        return int(uuid.UUID(obj.uuid).time_low)
+        return obj.id
 
     def prepare_title(self, obj):
         return str(obj)

--- a/geonode/groups/search_indexes.py
+++ b/geonode/groups/search_indexes.py
@@ -25,6 +25,7 @@ from django.conf import settings
 from haystack import indexes
 
 from geonode.groups.models import GroupProfile
+import uuid
 
 
 class GroupIndex(indexes.SearchIndex, indexes.Indexable):
@@ -33,12 +34,16 @@ class GroupIndex(indexes.SearchIndex, indexes.Indexable):
     # https://github.com/toastdriven/django-haystack/issues/569 - Necessary for sorting
     title_sortable = indexes.CharField(indexed=False)
     description = indexes.CharField(model_attr='description', boost=1.5)
-    id = indexes.IntegerField(model_attr='id')
+    id = indexes.IntegerField()
     type = indexes.CharField(faceted=True)
     json = indexes.CharField(indexed=False)
 
     def get_model(self):
         return GroupProfile
+
+    def prepare_id(self, obj):
+        # this is awful I'm so sorry
+        return int(uuid.UUID(obj.uuid).time_low)
 
     def prepare_title(self, obj):
         return str(obj)

--- a/geonode/layers/search_indexes.py
+++ b/geonode/layers/search_indexes.py
@@ -24,10 +24,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Avg
 from haystack import indexes
 from geonode.maps.models import Layer
+import uuid
 
 
 class LayerIndex(indexes.SearchIndex, indexes.Indexable):
-    id = indexes.IntegerField(model_attr='resourcebase_ptr_id')
+    id = indexes.IntegerField()
     abstract = indexes.CharField(model_attr="abstract", boost=1.5)
     category__gn_description = indexes.CharField(model_attr="category__gn_description", null=True)
     csw_type = indexes.CharField(model_attr="csw_type")
@@ -96,6 +97,10 @@ class LayerIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return Layer
+
+    def prepare_id(self, obj):
+        # this is awful I'm so sorry
+        return int(uuid.UUID(obj.uuid).time_low)
 
     def prepare_type(self, obj):
         return "layer"

--- a/geonode/maps/search_indexes.py
+++ b/geonode/maps/search_indexes.py
@@ -24,10 +24,11 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Avg
 from haystack import indexes
 from geonode.maps.models import Map
+import uuid
 
 
 class MapIndex(indexes.SearchIndex, indexes.Indexable):
-    id = indexes.IntegerField(model_attr='id')
+    id = indexes.IntegerField()
     abstract = indexes.CharField(model_attr="abstract", boost=1.5)
     category__gn_description = indexes.CharField(model_attr="category__gn_description", null=True)
     csw_type = indexes.CharField(model_attr="csw_type")
@@ -88,6 +89,10 @@ class MapIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return Map
+
+    def prepare_id(self, obj):
+        # this is awful I'm so sorry
+        return int(uuid.UUID(obj.uuid).time_low)
 
     def prepare_type(self, obj):
         return "map"

--- a/geonode/people/search_indexes.py
+++ b/geonode/people/search_indexes.py
@@ -39,7 +39,7 @@ class ProfileIndex(indexes.SearchIndex, indexes.Indexable):
 
     def prepare_id(self, obj):
         # this is awful I'm so sorry
-        return int(uuid.UUID(obj.uuid).time_low)
+        return obj.id
 
     def prepare_title(self, obj):
         return str(obj)

--- a/geonode/people/search_indexes.py
+++ b/geonode/people/search_indexes.py
@@ -20,10 +20,11 @@
 
 from haystack import indexes
 from geonode.people.models import Profile
+import uuid
 
 
 class ProfileIndex(indexes.SearchIndex, indexes.Indexable):
-    id = indexes.IntegerField(model_attr='id')
+    id = indexes.IntegerField()
     username = indexes.CharField(model_attr='username', null=True)
     first_name = indexes.CharField(model_attr='first_name', null=True)
     last_name = indexes.CharField(model_attr='last_name', null=True)
@@ -35,6 +36,10 @@ class ProfileIndex(indexes.SearchIndex, indexes.Indexable):
 
     def get_model(self):
         return Profile
+
+    def prepare_id(self, obj):
+        # this is awful I'm so sorry
+        return int(uuid.UUID(obj.uuid).time_low)
 
     def prepare_title(self, obj):
         return str(obj)


### PR DESCRIPTION
This is a PR for [NODE-1216] to correct the overwriting of indexes in elasticsearch.

Due to `Profile` and `GroupProfile` models lacking a UUID, they do not have a way to be fixed without adding them to the model.

Adding a UUID to the model is possible, but requires migrations to be written and may cause headaches that aren't worth it. This fix is intended to be short term until a complete rewrite of how we interact with elasticsearch is completed. It is a short term 'hack' to correct the way haystack indexes the data in elastic. Long term, we will need to either a) move away from haystack (preferred) or b) rewrite haystack's elasticsearch backend, which is where the bug resides.

Coincides with: https://github.com/boundlessgeo/exchange/pull/395