### PR TITLE
Better service registration error message

### DIFF
--- a/geonode/services/templates/services/service_register.html
+++ b/geonode/services/templates/services/service_register.html
@@ -41,7 +41,7 @@
         $("#service_register_form").submit(function(e) {
             var service_name_regexp = new RegExp('^[a-zA-Z]+[a-zA-Z0-9-_\.]*$');
             if(!service_name_regexp.test($("#id_name").val())) {
-                $("#warning").html("Service name must start with a letter, followed by letters, numbers, or the characters: . - _").show();
+                $("#warning").html("Service name must start with a letter, followed by letters, numbers, or the . - _ (period, dash, underscore) characters. No spaces allowed.").show();
                 $("#submit_button").prop("disabled",false);
                 return false;
             }


### PR DESCRIPTION
Update error message to spell out spaces and better specify allowed characters

> Service name must start with a letter, followed by letters, numbers, or the . - _ (period, dash, underscore) characters. No spaces allowed.