### PR TITLE
Fixed image downloads for time-enabled layers

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -334,7 +334,7 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
                       item.url and 'wms' not in item.url and 'gwc' not in item.url]
     for item in links_view:
         if item.url and access_token:
-            item.url = "%s&access_token=%s" % (item.url, access_token)
+            item.url = "%s&access_token=%s&time=%s" % (item.url, access_token, "0/9999")
     for item in links_download:
         if item.url and access_token:
             item.url = "%s&access_token=%s" % (item.url, access_token)


### PR DESCRIPTION
Added a default value for the "TIME" parameter for image downloads so that all features will be retrieved.

Fixes [BEX-225](https://issues.boundlessgeo.com:8443/browse/BEX-225)

Steps:
1. Upload a time-enabled layer, such as `american_civil_war_227b6a2b_abfc8178`, and enable time support.
2. In Exchange, navigate to `Data > Layers > [uploaded_layer]`.
3. Click `Download Layer`.
4. Click an image link in the `Images` tab.