### PR TITLE
assign custom AdminSite for app discovery.

### DIFF
--- a/geonode/admin.py
+++ b/geonode/admin.py
@@ -18,11 +18,12 @@
 #
 #########################################################################
 
-from django.contrib.admin import AdminSite
+from django.contrib import admin
 from django.utils.translation import ugettext_lazy
 from django.conf import settings
 
-class GeonodeAdminSite(AdminSite):
+
+class GeonodeAdminSite(admin.AdminSite):
 
     # The text to put at the top of each admin page, as an <h1> (a string).
     # By default, this is "Django administration".
@@ -36,4 +37,5 @@ class GeonodeAdminSite(AdminSite):
     # By default, this is "Site administration".
     index_title = '%s %s' % (settings.SITENAME, ugettext_lazy('Administration'))
 
-admin_site = GeonodeAdminSite()
+admin.site = GeonodeAdminSite()
+

--- a/geonode/urls.py
+++ b/geonode/urls.py
@@ -27,7 +27,6 @@ from django.views.generic import TemplateView
 from django.contrib import admin
 
 import geonode.proxy.urls
-from geonode.admin import admin_site
 from geonode.api.urls import api
 from geonode.api.views import verify_token, roles, users, admin_role
 
@@ -35,8 +34,6 @@ import autocomplete_light
 
 # Setup Django Admin
 autocomplete_light.autodiscover()
-
-admin.autodiscover()
 
 js_info_dict = {
     'domain': 'djangojs',
@@ -103,7 +100,7 @@ urlpatterns = patterns('',
 
                        (r'^i18n/', include('django.conf.urls.i18n')),
                        (r'^autocomplete/', include('autocomplete_light.urls')),
-                       (r'^admin/', include(admin_site.urls)),
+                       (r'^admin/', include(admin.site.urls)),
                        (r'^groups/', include('geonode.groups.urls')),
                        (r'^documents/', include('geonode.documents.urls')),
                        (r'^services/', include('geonode.services.urls')),


### PR DESCRIPTION
Without this change, the django admin page will not list any modules/apps.