### PR TITLE
Check for basic capabilities

### DIFF
--- a/geonode/services/forms.py
+++ b/geonode/services/forms.py
@@ -100,6 +100,15 @@ class CreateServiceForm(forms.Form):
             try:
                 service_handler = get_service_handler(
                     base_url=url, service_type=service_type)
+
+                if not service_handler.has_basic_capabilities():
+                    raise Warning('Basic Capabilities Not Supported')
+
+            except Warning:
+                raise ValidationError(
+                    _("Basic Capabilities not supported at %(url)s"),
+                    params={"url": url}
+                )
             except Exception:
                 raise ValidationError(
                     _("Could not connect to the service at %(url)s"),

--- a/geonode/services/serviceprocessors/base.py
+++ b/geonode/services/serviceprocessors/base.py
@@ -84,6 +84,9 @@ class ServiceHandlerBase(object):
 
         raise NotImplementedError
 
+    def has_basic_capabilities(self):
+        raise NotImplementedError
+
     def get_keywords(self):
         raise NotImplementedError
 

--- a/geonode/services/serviceprocessors/mapserver.py
+++ b/geonode/services/serviceprocessors/mapserver.py
@@ -106,6 +106,12 @@ class MapserverServiceHandler(base.ServiceHandlerBase,
     def get_keywords(self):
         return self.parsed_service.documentInfo['Keywords'].split(',')
 
+    def has_basic_capabilities(self):
+        if self.parsed_service.capabilities and 'Tilemap' in self.parsed_service.capabilities:
+            return True
+        else:
+            return False
+
     def get_resource(self, resource_id):
         return self.parsed_service.layers[int(resource_id)]
 

--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -87,6 +87,9 @@ class WmsServiceHandler(base.ServiceHandlerBase,
         )
         return instance
 
+    def has_basic_capabilities(self):
+        return True
+
     def get_keywords(self):
         return self.parsed_service.identification.keywords
 


### PR DESCRIPTION
MapLoom  assumes Tilemap is supported for ESRI REST services so we check the service for Tilemap support and prevent registration/import if its not available.

Service with Tilemap support:
http://services.arcgisonline.com/arcgis/rest/services/Demographics/USA_Median_Age/MapServer/

Service without TIlemap support:
https://maps.cityofmadison.com/arcgis/rest/services/Parking/OnStreetRestrictions/MapServer/

Error message:

<img width="1216" alt="screen shot 2018-01-22 at 6 38 54 pm" src="https://user-images.githubusercontent.com/947403/35251961-9e4af940-ffa3-11e7-8926-368b10ef3c6a.png">
