### PR TITLE
Use service_typename as it covers both local and remote

### DIFF
--- a/geonode/layers/models.py
+++ b/geonode/layers/models.py
@@ -305,7 +305,7 @@ class Layer(ResourceBase):
                 date=self.date,
                 type=self.prepare_type(),
                 subtype=self.prepare_subtype(),
-                typename=self.typename,
+                typename=self.service_typename,
                 title_sortable=self.prepare_title_sortable(),
                 category=self.prepare_category(),
                 bbox_left=self.bbox_x0,


### PR DESCRIPTION
This resolves the issue where the search results provide the incorrect typename if the layer is remote.