### PR TITLE
Add ptype and fix url for remote servers

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -750,11 +750,17 @@ def get_layer(request, layername):
         for style in layer_obj.styles.all():
             styles.append(style.name)
 
+        url = layer_obj.get_tiles_url()
+        if layer_obj.is_remote:
+            url = layer_obj.ows_url
+
         response = {
             'typename': layername,
             'name': layer_obj.name,
             'title': layer_obj.title,
-            'url': layer_obj.get_tiles_url(),
+            'ptype': layer_obj.ptype,
+            'url': url,
+            'remote': layer_obj.is_remote,
             'bbox_string': layer_obj.bbox_string,
             'bbox_x0': layer_obj.bbox_x0,
             'bbox_x1': layer_obj.bbox_x1,


### PR DESCRIPTION
1. Added ptype to allow the detail to delineate between
   ESRI and WMS type services.
2. Changed URL to switch between the server URL and the tiled URL
   based on whether the layer is local or remote.

refs: BEX-654