### PR TITLE
remove indexing from profile

### DIFF
--- a/geonode/people/models.py
+++ b/geonode/people/models.py
@@ -137,28 +137,6 @@ class Profile(AbstractUser):
     def location(self):
         return format_address(self.delivery, self.zipcode, self.city, self.area, self.country)
 
-    # elasticsearch_dsl indexing
-    def indexing(self):
-        if settings.ES_SEARCH:
-            from elasticsearch_app.search import ProfileIndex
-            obj = ProfileIndex(
-                meta={'id': self.id},
-                id=self.id,
-                username=self.username,
-                first_name=self.first_name,
-                last_name=self.last_name,
-                profile=self.profile,
-                organization=self.organization,
-                position=self.position,
-                type=self.prepare_type()
-            )
-            obj.save()
-            return obj.to_dict(include_meta=True)
-
-    # elasticsearch_dsl indexing helper functions
-    def prepare_type(self):
-        return "user"
-
 
 def get_anonymous_user_instance(Profile):
     return Profile(pk=-1, username='AnonymousUser')

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,6 @@ geonode-dialogos==0.7
 geonode-notification==1.1.1
 geonode-user-accounts==1.0.13
 geonode-user-messages==0.1.5
-geonode-elasticsearch-app==0.1.1
 gisdata==0.5.4
 gsconfig==1.0.6
 gsimporter==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -115,9 +115,6 @@ setup(name='GeoNode',
         # haystack/elasticsearch, uncomment to use
         "elasticsearch-dsl>=6.0.0,<7.0.0",
 
-        # elasticsearch-dsl app
-        "geonode-elasticsearch-app==0.2.1",
-
         # datetimepicker widget
         "django-bootstrap3-datetimepicker==2.2.3",
 


### PR DESCRIPTION
This PR makes sure that Exchange is handling bringing in geonode-elasticsearch app and removes the indexing function from the geonode model in order to further separate the functionality provided by this app.

Goes along with https://github.com/boundlessgeo/geonode-elasticsearch/pull/63

Also requires forthcoming PR to Exchange.