### PR TITLE
Use request.get_full_path()

### DIFF
--- a/geonode/security/middleware.py
+++ b/geonode/security/middleware.py
@@ -62,4 +62,4 @@ class LoginRequiredMiddleware(object):
                 return HttpResponseRedirect(
                     '{login_path}?next={request_path}'.format(
                         login_path=self.redirect_to,
-                        request_path=request.path))
+                        request_path=request.request.get_full_path()))


### PR DESCRIPTION
Returns the path, plus an appended query string, if applicable.

ISSUE:

If I am following a link to an Exchange installation that was sent to me by a colleague and I am redirected to the login screen when I click that link, the base link is the only portion of the original link preserved, so I lose the context of the shared link when I'm redirected after a successful login.

So:

https://exchange-dev.boundlessgeo.io/maps/new?layer=fibercable_377dcbaa

Becomes:

https://exchange-dev.boundlessgeo.io/maps/new

...after login.