### PR TITLE
Include perms dict in layer metadata response

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -761,6 +761,11 @@ def get_layer(request, layername):
         if layer_obj.is_remote:
             url = layer_obj.ows_url
 
+        permissions = { 'edit_style': False}
+
+        if request.user.has_perm('change_layer_style', obj=layer_obj):
+            permissions.update({'edit_style': True})     
+               
         response = {
             'typename': layername,
             'name': layer_obj.name,
@@ -775,6 +780,7 @@ def get_layer(request, layername):
             'bbox_y1': layer_obj.bbox_y1,
             'type': slugify(layer_obj.display_type),
             'styles': styles,
+            'permissions': permissions,
             'versioned': layer_obj.geogig_enabled,
             'attributes': attributes_as_json(layer_obj)
         }


### PR DESCRIPTION
Need an easy way for the caller of this method to determine whether the user has edit permissions to the layers style.

<img width="1147" alt="screen shot 2018-03-15 at 12 14 10 pm" src="https://user-images.githubusercontent.com/947403/37479906-d8b7c81c-284b-11e8-9e62-32d27d35e6d7.png">
