### PR TITLE
Backport: Use request.get_full_path() (#160)

### DIFF
--- a/geonode/security/middleware.py
+++ b/geonode/security/middleware.py
@@ -62,4 +62,4 @@ class LoginRequiredMiddleware(object):
                 return HttpResponseRedirect(
                     '{login_path}?next={request_path}'.format(
                         login_path=self.redirect_to,
-                        request_path=request.path))
+                        request_path=request.request.get_full_path()))


### PR DESCRIPTION
Returns the path, plus an appended query string, if applicable.

Backport from 1.5.x, to facilitate PKI work.