### PR TITLE
Adds default style filter, remote sync action, and perms management

### DIFF
--- a/geonode/base/admin.py
+++ b/geonode/base/admin.py
@@ -33,11 +33,13 @@ from treebeard.forms import movenodeform_factory
 
 from modeltranslation.admin import TranslationAdmin
 
+from guardian.admin import GuardedModelAdmin
+
 from geonode.base.models import (TopicCategory, SpatialRepresentationType, Region, RestrictionCodeType,
                                  ContactRole, Link, Backup, License, HierarchicalKeyword)
 
 
-class MediaTranslationAdmin(TranslationAdmin):
+class MediaTranslationAdmin(TranslationAdmin, GuardedModelAdmin):
     class Media:
         js = (
             'modeltranslation/js/tabbed_translation_fields.js',


### PR DESCRIPTION
This PR updates the django admin for layers to allow the admin user to filter layers by whether a default style has been set. The PR also enables a new Layers admin action to synchronize the registered styles with the active style records in Geoserver. Lastly, this PR enables object permissions to be managed via the django admin 'object permissions' button.

<img width="250" alt="screen shot 2018-03-28 at 9 44 36 am" src="https://user-images.githubusercontent.com/947403/38037309-372bc21e-326e-11e8-852b-e720a5e16e74.png">
<img width="324" alt="screen shot 2018-03-28 at 9 44 56 am" src="https://user-images.githubusercontent.com/947403/38037310-37810cc4-326e-11e8-9edc-f6bb612a1f68.png">
<img width="479" alt="screen shot 2018-03-28 at 9 59 45 am" src="https://user-images.githubusercontent.com/947403/38037589-d1538822-326e-11e8-855b-8d93eb0d4aaf.png">
<img width="1082" alt="screen shot 2018-03-28 at 9 59 54 am" src="https://user-images.githubusercontent.com/947403/38037590-d183a3c2-326e-11e8-8e8a-e1d97024ca76.png">

