### PR TITLE
Add default geoserver source

### DIFF
--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -493,6 +493,16 @@ def default_map_config(request):
 
     DEFAULT_MAP_CONFIG = _default_map.viewer_json(user, access_token, *DEFAULT_BASE_LAYERS)
 
+    if 'geonode.geoserver' in settings.INSTALLED_APPS:
+        next_id = len(DEFAULT_MAP_CONFIG['sources'].keys())
+        gs_public_url = settings.OGC_SERVER['default']['PUBLIC_LOCATION']
+        url = '%swms?access_token=%s' % (gs_public_url, access_token)
+        default_source = {'url': url,
+                    'restUrl': '/gs/rest',
+                    'ptype': 'gxp_wmscsource',
+                    'title': 'Local Geoserver'}
+        DEFAULT_MAP_CONFIG['sources'].update({str(next_id) : default_source})
+    
     return DEFAULT_MAP_CONFIG, DEFAULT_BASE_LAYERS
 
 


### PR DESCRIPTION
This PR sets the geoserver source for the default config only so that Maploom is able to preload the source although there are no layers included. When the layers= param is included for /maps/new, the local source is automatically added via the source layer.

Test Steps:

1. go to /maps/new
2. launch the layer add modal
3. Add a layer to the map

If this change is not applied, step 3 would fail.