### PR TITLE
Add a new map_params field to the map

### DIFF
--- a/geonode/maps/migrations/0028_map_map_params.py
+++ b/geonode/maps/migrations/0028_map_map_params.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('maps', '0027_auto_20180313_1430'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='map',
+            name='map_params',
+            field=models.TextField(verbose_name='map params', blank=True),
+        ),
+    ]

--- a/geonode/maps/models.py
+++ b/geonode/maps/models.py
@@ -97,6 +97,10 @@ class Map(ResourceBase, GXPMapBase):
     # Alphanumeric alternative to referencing maps by id, appended to end of
     # URL instead of id, ie http://domain/maps/someview
 
+    map_params = models.TextField(_('map params'), blank=True)
+    # A JSON-encoded dictionary of arbitrary parameters for the map itself when
+    # passed to the GXP viewer.
+
     featuredurl = models.CharField(
         _('Featured Map URL'),
         max_length=255,


### PR DESCRIPTION
Works similiarly to the layer_params field on layers, allows
storing a JSON object that describes additional map metadata.