### PR TITLE
Correct handling of bbox when projection is not EPSG:900913

### DIFF
--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -619,7 +619,7 @@ def new_map_config(request):
                     maplayer = MapLayer(map=map_obj,
                                         name=layer.typename,
                                         ows_url=layer.ows_url,
-                                        layer_params=json.dumps(config),
+                                        layer_params=json.dumps(config, cls=DjangoJSONEncoder),
                                         visibility=True,
                                         source_params=json.dumps({
                                             "ptype": service.ptype,


### PR DESCRIPTION
This bug results in a "JSON not serializable" error ( https://github.com/boundlessgeo/geonode/blob/exchange/1.5.x/geonode/maps/views.py#L622 ) when a remote layer is being processed due to the bbox containing `Decimal` values, which it does not like. Casting them to `float` fixes the problem (similar to what is done if the EPSG:900913 projection is used).

Apparently there is a `DjangoJSONEncoder` which can be used to handle the `Decimal` type, which may be appropriate to use instead. I can update to do that instead if it's more correct.