### PR TITLE
backport

### DIFF
--- a/geonode/layers/templates/layers/layer_granule_remove.html
+++ b/geonode/layers/templates/layers/layer_granule_remove.html
@@ -5,7 +5,7 @@
 
 {% block body %}
 <div class="page-header">
-  <a href="{% url "layer_browse" %}" class="btn btn-primary pull-right">{% trans "Explore Layers" %}</a>
+  <a href="{% url "search" %}?type=layer" class="btn btn-primary pull-right">{% trans "Explore Layers" %}</a>
   <h2 class="page-title">{% trans "Remove Mosaic Granules" %}</h2>
 </div>
 <div class="row">

--- a/geonode/layers/templates/layers/layer_metadata.html
+++ b/geonode/layers/templates/layers/layer_metadata.html
@@ -8,7 +8,7 @@
 
 {% block body_outer %}
 <div class="page-header">
-  <a href="{% url "layer_browse" %}" class="btn btn-primary pull-right">{% trans "Explore Layers" %}</a>
+  <a href="{% url "search" %}?type=layer" class="btn btn-primary pull-right">{% trans "Explore Layers" %}</a>
   <h2 class="page-title">{% trans "Edit Metadata" %}</h2>
 </div>
 <div class="row">

--- a/geonode/layers/templates/layers/layer_remove.html
+++ b/geonode/layers/templates/layers/layer_remove.html
@@ -5,7 +5,7 @@
 
 {% block body %}
 <div class="page-header">
-  <a href="{% url "layer_browse" %}" class="btn btn-primary pull-right">{% trans "Explore Layers" %}</a>
+  <a href="{% url "search" %}?type=layer" class="btn btn-primary pull-right">{% trans "Explore Layers" %}</a>
   <h2 class="page-title">{% trans "Remove Layers" %}</h2>
 </div>
 <div class="row">


### PR DESCRIPTION
The search filters are missing when a user clicks on the Explore Layers button from the edit metadata or the replace layer page. The user is returned to the Layers page but the only search filters visible are text, date and extent.
The facets begin to load and then disappear
STEPS:

Data, Layers
View Details of a layer
Edit Layer
Click on Edit Metadata or Replace Layer Page
Click Explore Layer