### PR TITLE
Pass in layerid param to viewer GXPLayer - the ArcREST tile source us…

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -270,6 +270,8 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
             "use_proxy": use_proxy}
         if query_params is not None:
             source_params["params"] = query_params
+        if layer.alternate is not None:
+            config["layerid"] = layer.alternate
         maplayer = GXPLayer(
             name=layer.typename,
             ows_url=layer.ows_url,

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -623,6 +623,8 @@ def new_map_config(request):
                         url = service.base_url
                     use_proxy = (callable(uses_proxy_route)
                                  and uses_proxy_route(service.base_url))
+                    if layer.alternate is not None:
+                        config["layerid"] = layer.alternate
                     maplayer = MapLayer(map=map_obj,
                                         name=layer.typename,
                                         ows_url=layer.ows_url,


### PR DESCRIPTION
…es layerid to select layer from source. This id is stored in layer.alternate in Exchange, see https://github.com/boundlessgeo/exchange/blob/ps/pki/exchange/templates/layers/layer_detail.html#L324
Also used there for generating the correct source URL