### PR TITLE
Reconfigure use of CLASSIFICATION_LEVELS

### DIFF
--- a/geonode/services/forms.py
+++ b/geonode/services/forms.py
@@ -44,11 +44,20 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 def get_classifications():
-        return [(x, str(x)) for x in getattr(settings, 'CLASSIFICATION_LEVELS', [])]
+    #return [(x, str(x)) for x in getattr(settings, 'CLASSIFICATION_LEVELS', [])]
+    classification_dict = getattr(settings, 'CLASSIFICATION_LEVELS', {})
+    return [(x, str(x)) for x in list(classification_dict.keys())]
 
 
 def get_caveats():
-        return [(x, str(x)) for x in getattr(settings, 'CAVEATS', [])]
+    #return [(x, str(x)) for x in getattr(settings, 'CAVEATS', [])]
+    classification_dict = getattr(settings, 'CLASSIFICATION_LEVELS', {})
+    caveats = []
+
+    for key in classification_dict.keys():
+        caveats.extend([(x, str(x)) for x in classification_dict[key]])
+
+    return set(caveats)
 
 
 def get_provenances():

--- a/geonode/services/forms.py
+++ b/geonode/services/forms.py
@@ -44,13 +44,13 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 def get_classifications():
-    #return [(x, str(x)) for x in getattr(settings, 'CLASSIFICATION_LEVELS', [])]
     classification_dict = getattr(settings, 'CLASSIFICATION_LEVELS', {})
     return [(x, str(x)) for x in list(classification_dict.keys())]
 
 
+
+
 def get_caveats():
-    #return [(x, str(x)) for x in getattr(settings, 'CAVEATS', [])]
     classification_dict = getattr(settings, 'CLASSIFICATION_LEVELS', {})
     caveats = []
 

--- a/geonode/services/templates/services/service_edit.html
+++ b/geonode/services/templates/services/service_edit.html
@@ -22,3 +22,39 @@
   </div>
 </form>
 {% endblock %}
+
+{% block extra_script %}
+{{ block.super }}
+<script type="text/javascript">
+  $(document).ready(function () {
+    {% autoescape on %}
+    var classification_mapping = {{ classification_levels | safe }};
+    {% endautoescape %}
+    var classification_dropdown = $('#id_service-classification')[0];
+    var caveat_dropdown = $('#id_service-caveat')[0];
+
+    var get_caveats_from_classification = function (classification) {
+      return classification_mapping[classification]
+    };
+
+    var update_caveats = function () {
+
+      while(caveat_dropdown.options.length) {
+        caveat_dropdown.remove(0);
+      }
+
+      var caveats = get_caveats_from_classification(classification_dropdown.value);
+      var i;
+      for (i = 0; i < caveats.length; i++) {
+        caveat_dropdown.add(new Option(caveats[i], i));
+      }
+    };
+
+    update_caveats();
+
+    classification_dropdown.onchange = function(){
+      update_caveats();
+    };
+  });
+</script>
+{% endblock %}

--- a/geonode/services/views.py
+++ b/geonode/services/views.py
@@ -307,6 +307,7 @@ def edit_service(request, service_id):
     Edit an existing Service
     """
     service_obj = get_object_or_404(Service, pk=service_id)
+    classification_dict = getattr(settings, "CLASSIFICATION_LEVELS", {})
 
     if request.method == "POST":
         service_form = forms.ServiceForm(
@@ -325,7 +326,8 @@ def edit_service(request, service_id):
     return render_to_response("services/service_edit.html",
                               RequestContext(request,
                                              {"service": service_obj,
-                                              "service_form": service_form}))
+                                              "service_form": service_form,
+                                              "classification_levels": classification_dict}))
 
 
 @login_required


### PR DESCRIPTION
It was determined that it is important to be able
to specify which caveats should be applied to which
classification. This change tweaks the CLASSIFICATION_LEVELS
setting, and makes use of the new format to ensure
only the caveats that apply to a particular classification
are able to be selected.