### PR TITLE
Allow the app to skip the local login page and force redirect to the external auth provider.

### DIFF
--- a/geonode/security/middleware.py
+++ b/geonode/security/middleware.py
@@ -55,6 +55,11 @@ class LoginRequiredMiddleware(object):
             ()))
     redirect_to = reverse('account_login')
 
+    if settings.ENABLE_SOCIAL_LOGIN and hasattr(settings,
+                                                'DEFAULT_SOCIAL_PROVIDER'):
+        redirect_to = reverse('social:begin',
+                              args=[settings.DEFAULT_SOCIAL_PROVIDER])
+
     def process_request(self, request):
         if not request.user.is_authenticated(
         ) or request.user == get_anonymous_user():


### PR DESCRIPTION
With this setting enabled, Exchange will bypass the local login page and force redirect to the user to login via the external provider.