### PR TITLE
Update layer args

### DIFF
--- a/geonode/contrib/createlayer/utils.py
+++ b/geonode/contrib/createlayer/utils.py
@@ -69,14 +69,11 @@ def create_gn_layer(workspace, datastore, name, title, owner_name):
         workspace=workspace.name,
         store=datastore.name,
         storeType='dataStore',
-        alternate='%s:%s' % (workspace.name, name),
+        alternate='{}'.format(name.encode('utf-8')),
+        typename='{}'.format(name.encode('utf-8')),
         title=title,
         owner=owner,
-        uuid=str(uuid.uuid4()),
-        bbox_x0=-180,
-        bbox_x1=180,
-        bbox_y0=-90,
-        bbox_y1=90
+        uuid=str(uuid.uuid4())
     )
     return layer
 

--- a/geonode/contrib/createlayer/utils.py
+++ b/geonode/contrib/createlayer/utils.py
@@ -248,7 +248,7 @@ def create_gs_layer(name, title, geometry_type, attributes=None):
            "<nativeName>{native_name}</nativeName>"
            "<title>{title}</title>"
            "<srs>EPSG:4326</srs>"
-           "<latLonBoundingBox><minx>-180</minx><maxx>180</maxx><miny>-90</miny><maxy>90</maxy>"
+           "<latLonBoundingBox><minx>-1</minx><maxx>0</maxx><miny>-1</miny><maxy>0</maxy>"
            "<crs>EPSG:4326</crs></latLonBoundingBox>"
            "{attributes}"
            "</featureType>").format(

--- a/geonode/layers/urls.py
+++ b/geonode/layers/urls.py
@@ -31,6 +31,7 @@ urlpatterns = patterns(
     url(r'^$', TemplateView.as_view(template_name='layers/layer_list.html'), {'is_layer': True}, name='layer_browse'),
     url(r'^upload$', 'layer_upload', name='layer_upload'),
     url(r'^(?P<layername>[^/]*)$', 'layer_detail', name="layer_detail"),
+    url(r'^(?P<layername>[^/]*)/recalculate$', 'layer_update_bounds', name="layer_recalulate_bound"),
     url(r'^(?P<layername>[^/]*)/metadata$', 'layer_metadata', name="layer_metadata"),
     url(r'^(?P<layername>[^/]*)/remove$', 'layer_remove', name="layer_remove"),
     url(r'^(?P<granule_id>[^/]*)/(?P<layername>[^/]*)/granule_remove$', 'layer_granule_remove',

--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -67,6 +67,8 @@ from geonode.utils import build_social_links
 from geonode.geoserver.helpers import cascading_delete, gs_catalog
 from geonode.geoserver.helpers import ogc_server_settings
 
+from geonode.contrib.createlayer.utils import update_gs_layer_bounds
+
 if 'geonode.geoserver' in settings.INSTALLED_APPS:
     from geonode.geoserver.helpers import _render_thumbnail
 CONTEXT_LOG_FILE = ogc_server_settings.LOG_FILE
@@ -220,6 +222,23 @@ def layer_upload(request, template='upload/layer_upload.html'):
             json.dumps(out),
             content_type='application/json',
             status=status_code)
+
+
+def layer_update_bounds(request, layername):
+    layer = _resolve_layer(
+        request,
+        layername,
+        'base.view_resourcebase',
+        _PERMISSION_MSG_VIEW)
+
+    update_gs_layer_bounds(layername)
+
+    layer.save()
+
+    return HttpResponse(
+        json.dumps({'data': '{} bbox has been updated.'.format(layername)}),
+        content_type='application/json',
+        status=200)
 
 
 def layer_detail(request, layername, template='layers/layer_detail.html'):


### PR DESCRIPTION
Since Exchange uploads remove the `geonode:` from the type name, lets follow the same approach for create layer. Also there's no need to set the bbox info because it get overridden by the Geoserver response.

This PR also addresses the following BEX-987 items:

1. Extent issue when the layer is reloaded in Maploom when a feature has been added. The map does not zoom to the correct location of the feature
2. Missing basemap and map preview under layer details page

Error Test Steps:

Points, Lines and Polygons
STEPS:
- Data, Create Layer
- Create point, line or polygon layer
- Add attribute
- Create
- In maploom, Add a feature
- Show style editor
- Make changes to the style and Save
- Error

- For the same created layer, add a feature. *Note:* Requires an update to MapLoom which will call /recalculate each time a feature is added or updated.
- search for the layer and the thumbnail should be updated to reflect the new feature
- view the layer details page and the bbox should be updated to include the newly added feature.