### PR TITLE
Prevent view only users from adding data

### DIFF
--- a/geonode/contrib/createlayer/templates/createlayer/layer_create.html
+++ b/geonode/contrib/createlayer/templates/createlayer/layer_create.html
@@ -18,6 +18,9 @@
 
 <div class="page-header">
   <h2 class="page-title">{% trans "Create an empty layer" %}</h2>
+  {% if user.content_creator == False %}
+    <p>You are not a Content Creator, so you may not create a layer. Please contact an Administator if you believe you should be a Content Creator.</p>
+  {% endif %}
 </div>
 
 <div class="row">
@@ -106,6 +109,11 @@
       $('#attributes').val(JSON.stringify(attrs));
     });
 
+    // disable layer creation button and add attribute button if user is not a content creator
+    if ('{{ user.content_creator }}' != 'True') {
+        $('#add-attr-button').prop('disabled', true);
+        $('#layer-create-button').prop('disabled', true);
+    }
 </script>
 
 {% endblock extra_script %}

--- a/geonode/contrib/createlayer/views.py
+++ b/geonode/contrib/createlayer/views.py
@@ -36,7 +36,7 @@ def layer_create(request, template='createlayer/layer_create.html'):
     Create an empty layer.
     """
     error = None
-    if request.method == 'POST':
+    if request.method == 'POST' and request.user.content_creator is True:
         form = NewLayerForm(request.POST)
         if form.is_valid():
             try:
@@ -57,7 +57,7 @@ def layer_create(request, template='createlayer/layer_create.html'):
     ctx = {
         'form': form,
         'is_layer': True,
-        'error': error,
+        'error': error
     }
 
     return render_to_response(template, RequestContext(request, ctx))

--- a/geonode/documents/templates/documents/document_upload.html
+++ b/geonode/documents/templates/documents/document_upload.html
@@ -70,5 +70,8 @@
     $('#upload_form').submit(function(){
       $('#permissions').val(JSON.stringify(permissionsString($('#permission_form'),'base')));
     });
+    if ('{{ user.content_creator }}' != 'True') {
+      $('#upload-button').prop('disabled', true);
+    }
 </script>
 {% endblock extra_script %}

--- a/geonode/documents/templates/documents/document_upload_base.html
+++ b/geonode/documents/templates/documents/document_upload_base.html
@@ -10,6 +10,10 @@
 <div class="page-header">
   <a href="{% url "document_browse" %}" class="btn btn-primary pull-right">{% trans "Explore Documents" %}</a>
   <h2 class="page-title">{% trans "Upload Documents" %}</h2>
+	{% if user.content_creator == False %}
+	  <p>You are not a Content Creator, so you may not upload a document. Please contact an Administator if you believe you should be a Content Creator.</p>
+	  <br/>
+	{% endif %}
 	<p>Allowed document types:</p>
 	<p>
 	{% for doc in ALLOWED_DOC_TYPES %}

--- a/geonode/people/admin.py
+++ b/geonode/people/admin.py
@@ -53,6 +53,7 @@ class ProfileAdmin(admin.ModelAdmin):
         (None, {'fields': ('username', 'password')}),
         (_('Personal info'), {'fields': ('first_name', 'last_name', 'email')}),
         (_('Permissions'), {'fields': ('is_active', 'is_staff', 'is_superuser',
+                                       'content_creator', 'content_manager',
                                        'groups')}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
         (_('Extended profile'), {'fields': ('organization', 'profile',

--- a/geonode/people/migrations/0025_auto_20180806_1248.py
+++ b/geonode/people/migrations/0025_auto_20180806_1248.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('people', '24_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='content_creator',
+            field=models.BooleanField(default=True, help_text='User can upload layers and documents', verbose_name='Content Creator'),
+        ),
+        migrations.AddField(
+            model_name='profile',
+            name='content_manager',
+            field=models.BooleanField(default=True, help_text='User can register remote services', verbose_name='Content Creator'),
+        ),
+    ]

--- a/geonode/people/models.py
+++ b/geonode/people/models.py
@@ -97,6 +97,14 @@ class Profile(AbstractUser):
     keywords = TaggableManager(_('keywords'), blank=True, help_text=_(
         'commonly used word(s) or formalised word(s) or phrase(s) used to describe the subject \
             (space or comma-separated'))
+    content_creator = models.BooleanField(
+        _('Content Creator'),
+        default=True,
+        help_text=_('User can upload layers and documents'))
+    content_manager = models.BooleanField(
+        _('Content Manager'),
+        default=True,
+        help_text=_('User can register remote services'))
 
     def get_absolute_url(self):
         return reverse('profile_detail', args=[self.username, ])

--- a/geonode/services/templates/services/service_list.html
+++ b/geonode/services/templates/services/service_list.html
@@ -5,8 +5,11 @@
 
 {% block body_outer %}
 <div class="page-header">
-  <a href="{% url "register_service" %}" class="btn btn-primary pull-right">{% trans "Register a new Service" %}</a>
+  <a href="{% url "register_service" %}" class="btn btn-primary pull-right" id="service_register_button">{% trans "Register a new Service" %}</a>
   <h2>{% trans "Remote Services" %}</h2>
+  {% if user.content_manager == False %}
+    <p>You are not a Content Manager, so you may not register a service. Please contact an Administator if you believe you should be a Content Manager.</p>
+  {% endif %}
 </div>
 <div class="twocol">
 {% if services %}
@@ -32,4 +35,15 @@
 <h4>No services registered</h4>
 {% endif %}
 </div>
+{% endblock %}
+{% block extra_script %}
+{{ block.super }}
+<script type="text/javascript">
+$(document).ready(function () {
+    // disable service registration button if user is not a content manager
+    if ('{{ user.content_manager }}' != 'True') {
+        $('#service_register_button').attr('disabled', true);
+    }
+})
+</script>
 {% endblock %}

--- a/geonode/services/templates/services/service_register.html
+++ b/geonode/services/templates/services/service_register.html
@@ -12,6 +12,9 @@
 <div class="page-header">
   <h2>{% trans "Register New Service" %}</h2>
 </div>
+    {% if user.content_manager == False %}
+    <p>You are not a Content Manager, so you may not register a service. Please contact an Administator if you believe you should be a Content Manager.</p>
+    {% endif %}
     <form method="POST" id="service_register_form">
     {% csrf_token %}
     {{ form|as_bootstrap }}
@@ -52,6 +55,10 @@
 {{ block.super }}
 <script type="text/javascript">
 $(document).ready(function () {
+    // disable service registration button if user is not a content manager
+    if ('{{ user.content_manager }}' != 'True') {
+        $('#submit_button').prop('disabled', true);
+    }
     $('#service_register_form').submit(function () {
         $("#progressModal").modal("show");
     });

--- a/geonode/services/views.py
+++ b/geonode/services/views.py
@@ -52,14 +52,15 @@ def services(request):
     return render(
         request,
         "services/service_list.html",
-        {"services": Service.objects.all()}
+        {"services": Service.objects.all(),
+         "profile": request.user}
     )
 
 
 @login_required
 def register_service(request):
     service_register_template = "services/service_register.html"
-    if request.method == "POST":
+    if request.method == "POST" and request.user.content_manager is True:
         form = forms.CreateServiceForm(request.POST)
         if form.is_valid():
             service_handler = form.cleaned_data["service_handler"]


### PR DESCRIPTION
Adds the "Content Manager" and "Content Creator" fields to the `Profile` model. The "Content Manager" field determines if a user may register remote services. The "Content Creator" field determines if a user may upload documents or layers.

The templates and views have been updated to use these fields to prevent operations as necessary. The user is allowed to go to the view, but the buttons will be disabled, and `POST` requests ignored if the user does not have the correct permissions.

Because a model change is made to the `Profile` model, migrations are necessary and included.