### PR TITLE
Slugify the name for consistency

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -840,7 +840,7 @@ def get_layer(request, layername):
                
         response = {
             'typename': layername,
-            'name': layer_obj.name,
+            'name': slugify(layer_obj.name),
             'title': layer_obj.title,
             'ptype': layer_obj.ptype,
             'workspace': layer_obj.workspace,


### PR DESCRIPTION
User is seeing remote service layers showing up disabled when a map is saved with only remote services and then reloaded from Explore Maps. The user is able to successfully add the remote service layers and save the map but when the map is reloaded from Explore Maps, the layers show up disabled.
This issue is occurring when the Add Layer dialog in Maploom is used
STEPS:
- Create map
- Add Remote Services from Add Layer Dialog
- Save map
- Maps, Explore Maps
- Click on the saved map to open
- Layers show up disabled

