### PR TITLE
Redirect to search instead

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -768,7 +768,7 @@ def layer_remove(request, layername, template='layers/layer_remove.html'):
 
             messages.error(request, message)
             return render_to_response(template, RequestContext(request, {"layer": layer}))
-        return HttpResponseRedirect(reverse("layer_browse"))
+        return HttpResponseRedirect(reverse("search"))
     else:
         return HttpResponse("Not allowed", status=403)
 


### PR DESCRIPTION
Seeing a few issues with removing layers
- Removing a layer is causing the thumbnails to turn white when the user is returned to the search page
- User is unable to click on the thumbnail to create a map
- All other layers will not load in Maploom when the user clicks on the name of the layer to create a map
- Deleted layer remains in search, clicking on the name or view details causes a page error
- *All reported issues resolve if the user refreshes the browser or navigates to another page*

STEPS:
- Data, Layers
- View Details
- Edit Layer
- Remove Layer
- Yes