### PR TITLE
One layer minimum

### DIFF
--- a/geonode/services/serviceprocessors/wms.py
+++ b/geonode/services/serviceprocessors/wms.py
@@ -160,7 +160,7 @@ class WmsServiceHandler(base.ServiceHandlerBase,
         geonode_layer.save()
 
     def has_resources(self):
-        return True if len(self.parsed_service.contents) > 1 else False
+        return True if len(self.parsed_service.contents) > 0 else False
 
     def _create_layer_thumbnail(self, geonode_layer):
         """Create a thumbnail with a WMS request."""


### PR DESCRIPTION
This service failed to register because it only has one advertised layer. This PR prevents the one layer exclusion and checks for > 0.

https://basemap.nationalmap.gov/arcgis/services/USGSImageryTopo/MapServer/WMSServer?request=GetCapabilities&service=WMS