### PR TITLE
Clear perms for non-layers

### DIFF
--- a/geonode/security/models.py
+++ b/geonode/security/models.py
@@ -443,17 +443,17 @@ def remove_object_permissions(instance):
         except:
             logger.debug(traceback.format_exc())
 
-        try:
-            UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
+    try:
+        UserObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
                                                 object_pk=instance.id).delete()
-        except:
-            logger.debug(traceback.format_exc())
+    except:
+        logger.debug(traceback.format_exc())
 
-        try:
-            GroupObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
+    try:
+        GroupObjectPermission.objects.filter(content_type=ContentType.objects.get_for_model(resource),
                                                  object_pk=instance.id).delete()
-        except:
-            logger.debug(traceback.format_exc())
+    except:
+        logger.debug(traceback.format_exc())
 
 
 # Logic to login a user automatically when it has successfully


### PR DESCRIPTION
The change permissions for documents and maps is not saving when unchecking Anyone and applying the changes.

A map or document that has its permissions changed to just admin is still available for the test user when they log on. The test user can view the document and is able to open the map but the layer is disabled in Maploom.

STEPS:
- Login with Admin
- Upload a document
- Change document permissions
- Remove Anyone and Apply Changes for just admin
- Login with Test
- Document is available 
or
- Login with Admin
- Select and create a map with a layer
- Save Map
- Maps, Explore Maps, View Details
- Change Map Permisisons
- Remove Anyone and Apply changes 