### PR TITLE
GeoNode bug fixes and PKI preparation

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -255,7 +255,7 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
     # Add required parameters for GXP lazy-loading
     layer_bbox = layer.bbox
     bbox = [float(coord) for coord in list(layer_bbox[0:4])]
-    config["srs"] = getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:900913')
+    config["srs"] = layer.srid if layer.srid else getattr(settings, 'DEFAULT_MAP_CRS', 'EPSG:900913')
     config["bbox"] = bbox if config["srs"] != 'EPSG:900913' \
         else llbbox_to_mercator([float(coord) for coord in bbox])
     config["title"] = layer.title

--- a/geonode/services/forms.py
+++ b/geonode/services/forms.py
@@ -36,11 +36,16 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 def get_classifications():
-        return [(x, str(x)) for x in getattr(settings, 'CLASSIFICATION_LEVELS', [])]
+    classification_dict = getattr(settings, 'CLASSIFICATION_LEVELS', {})
+    return [(x, str(x)) for x in list(classification_dict.keys())]
 
 
 def get_caveats():
-        return [(x, str(x)) for x in getattr(settings, 'CAVEATS', [])]
+    classification_dict = getattr(settings, 'CLASSIFICATION_LEVELS', {})
+    caveats = []
+    for key in classification_dict.keys():
+        caveats.extend([(x, str(x)) for x in classification_dict[key]])
+    return set(caveats)
 
 
 def get_provenances():

--- a/geonode/services/serviceprocessors/mapserver.py
+++ b/geonode/services/serviceprocessors/mapserver.py
@@ -150,7 +150,8 @@ class MapserverServiceHandler(base.ServiceHandlerBase,
 
         """
 
-        return list(self.parsed_service.layers)
+        return [] if self.parsed_service.layers is None else \
+            list(self.parsed_service.layers)
 
     def harvest_resource(self, resource_id, geonode_service):
         """Harvest a single resource from the service

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -911,7 +911,7 @@ def designals():
             # first tuple element:
             # - case (id(instance), id(method))
             if not isinstance(signal[0], tuple):
-                raise "Malformed signal"
+                raise Exception("Malformed signal")
 
             lookup = signal[0]
 

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(name='GeoNode',
         "geonode-announcements==1.0.9",
         "geonode-agon-ratings==0.3.5",  # (0.3.1 in ppa) FIXME
         "geonode-user-accounts==1.0.13",  # (1.0.11 in ppa) FIXME
-        "geonode-arcrest==10.2",
+        #"geonode-arcrest==10.2",
         "geonode-notification==1.1.3",
         "geonode-dialogos==0.7",
         # "gsconfig==1.0.8",  # (1.0.3 in ppa) FIXME
@@ -119,8 +119,8 @@ setup(name='GeoNode',
         "django-storages==1.1.8",
 
         # https://github.com/benjaminp/six/issues/210
-        "six==1.10.0",
-        'ArcREST-Package==3.5.9'
+        "six==1.10.0"
+        #'ArcREST-Package==3.5.9'
         ],
       zip_safe=False,
       )


### PR DESCRIPTION
New PR for https://github.com/boundlessgeo/geonode/pull/249

Since we do not want to put changes in GeoNode, the old code changes are going to be extracted into the Exchange PR and a custom app. These changes are all that will be relevant for GeoNode now.

### Change Summary

**layers/views.py**
bug fix for using correct proj in JS clients

**services/serviceprocessors/mapserver.py**
bug fix for empty layers list in list of parsed_service layers

**utils.py**
bug fix for incorrect syntax on raised exception

**setup.py**
removal of ArcREST installation from GeoNode so that our custom ArcREST package will be installed (this is actually the only portion relevant to getting PKI working)

**services/forms.py**
refactors how we use the `CLASSIFICATION_LEVELS` and `CAVEATS` variables in accordance with adjustments to their settings in Exchange