### PR TITLE
Fix for third party login issues

### DIFF
--- a/geonode/base/models.py
+++ b/geonode/base/models.py
@@ -984,7 +984,10 @@ def do_login(sender, user, request, **kwargs):
                 logging.debug("Using token from social authentication.")
                 social_user = user.social_user
                 token = social_user.extra_data.get('access_token')
-                ttl = social_user.extra_data.get('expires') or ttl
+                if len(token) > 255:
+                    token = generate_token()
+                if expires:
+                    ttl = int(expires)
             else:
                 logging.debug("Generating a local access token.")
                 token = generate_token()


### PR DESCRIPTION
This is a workaround to synchronize tokens between Exchange and Geoserver for Anywhere. This commit address the case where the token is larger than the db field and well as when the value of expires is a string.