### PR TITLE
Increase page refresh timer on harvest

### DIFF
--- a/geonode/services/templates/services/service_resources_harvest.html
+++ b/geonode/services/templates/services/service_resources_harvest.html
@@ -58,7 +58,7 @@
         {% else %}
             <p>{% trans "All resources have already been imported" %}</p>
             <script type="application/javascript">
-                setTimeout(function(){ window.location = "/services/{{ service.id }}" }, 1000);
+                setTimeout(function(){ window.location = "/services/{{ service.id }}" }, 10000);
             </script>
         {% endif %}
         <div class="modal fade" data-backdrop="static" data-keyboard="false" id="progressModal" tabindex="-1" role="dialog" aria-labelledby="progressModalLabel">


### PR DESCRIPTION
On systems with poor network responsiveness
the low refresh time causes the harvest page
to become unusable in the event that a resource
fails to be harvested. This new timeout should
strike a balance between refreshing the page
frequently enough to update the status of "IN
PROGRESS" items without breaking things in the
event of a failure.