### PR TITLE
Cast bbox to list to prevent tuple error

### DIFF
--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -591,6 +591,7 @@ def new_map_config(request):
                 if bbox is None:
                     bbox = list(layer_bbox[0:4])
                 else:
+                    bbox = list(bbox)
                     bbox[0] = min(bbox[0], layer_bbox[0])
                     bbox[1] = max(bbox[1], layer_bbox[1])
                     bbox[2] = min(bbox[2], layer_bbox[2])


### PR DESCRIPTION
Cast `bbox` to a list, as it can otherwise end up here as a `tuple` object, which will cause failures when loading in MapLoom. This error seems to occur only when:

- The Layers are harvested from a WMS Service
- Multiple of said Layers are selected in the workspace and opened in map viewer