### PR TITLE
Fixing incorrect loading of bbox for remote services

### DIFF
--- a/geonode/layers/views.py
+++ b/geonode/layers/views.py
@@ -264,7 +264,8 @@ def layer_detail(request, layername, template='layers/layer_detail.html'):
         config["styles"] = layer.default_style.name
 
     if layer.storeType == "remoteStore":
-        reprojected_bbox = bbox_to_projection(bbox, source_srid=layer.srid, target_srid=3857)
+        target_srid = 3857 if config["srs"] == 'EPSG:900913' else config["srs"]
+        reprojected_bbox = bbox_to_projection(bbox, source_srid=layer.srid, target_srid=target_srid)
         bbox = reprojected_bbox[:4]
         config['bbox'] = [float(coord) for coord in bbox]
         service = layer.service

--- a/geonode/maps/views.py
+++ b/geonode/maps/views.py
@@ -614,7 +614,8 @@ def new_map_config(request):
                     ogc_server_url = urlparse.urlsplit(ogc_server_settings.PUBLIC_LOCATION).netloc
                     service_url = urlparse.urlsplit(service.base_url).netloc
 
-                    reprojected_bbox = bbox_to_projection(bbox, source_srid=layer.srid, target_srid=3857)
+                    target_srid = 3857 if config["srs"] == 'EPSG:900913' else config["srs"]
+                    reprojected_bbox = bbox_to_projection(bbox, source_srid=layer.srid, target_srid=target_srid)
                     bbox = reprojected_bbox[:4]
                     config['bbox'] = [float(coord) for coord in bbox]
                     

--- a/geonode/utils.py
+++ b/geonode/utils.py
@@ -197,7 +197,7 @@ def bbox_to_projection(native_bbox, source_srid=4326, target_srid=4326):
     """
     box = native_bbox[:4]
     proj = source_srid
-    minx, maxx, miny, maxy = [float(a) for a in box]
+    minx, miny, maxx, maxy = [float(a) for a in box]
     try:
         source_srid = int(proj.split(":")[1]) if proj and ':' in proj else int(proj)
     except BaseException:


### PR DESCRIPTION
Fixes the geonode-client's bbox to take into account the settings for our target srid.
Also corrects the ordering of the bbox in `bbox_to_projection` to match what is returned by the model.

Coincides with: https://github.com/boundlessgeo/exchange/pull/62