### PR TITLE
Fix Return to Layers button on replace page

### DIFF
--- a/geonode/layers/templates/layers/layer_replace.html
+++ b/geonode/layers/templates/layers/layer_replace.html
@@ -8,6 +8,13 @@
 
 {% block extra_head %}{{ block.super }}{% endblock %}
 
+{% block page_header %}
+<div class="page-header">
+  <a href="{{ layer.get_absolute_url }}" class="btn btn-primary pull-right">{% trans "Return to Layer" %}</a>
+  <h2 class="page-title">{% trans "Upload Layers" %}</h2>
+</div>
+{% endblock page_header %}
+
 {% block head %}
 
 {{ block.super }}

--- a/geonode/layers/templates/upload/layer_upload_base.html
+++ b/geonode/layers/templates/upload/layer_upload_base.html
@@ -7,10 +7,12 @@
 {% block body_class %}data{% endblock %}
 
 {% block body_outer %}
+{% block page_header %}
 <div class="page-header">
   <a href="{% url "layer_browse" %}" class="btn btn-primary pull-right">{% trans "Explore Layers" %}</a>
   <h2 class="page-title">{% trans "Upload Layers" %}</h2>
 </div>
+{% endblock page_header %}
 <div class="row">
   {% block body %}{% endblock body %}
   {% block sidebar %}{% endblock sidebar %}


### PR DESCRIPTION
Previously the button pointed to the explore layers
section. This makes sense when you are trying to
upload a layer in general, (which is the template
the layer replace page inherits from) however when
you're replacing a specific layer, it makes more
sense to return to that specific layer as your
"go back" action.