### PR TITLE
ignore encoding errors

### DIFF
--- a/geonode/services/serviceprocessors/mapserver.py
+++ b/geonode/services/serviceprocessors/mapserver.py
@@ -327,7 +327,8 @@ class MapserverServiceHandler(base.ServiceHandlerBase,
                 str(layer_meta.id))
 
         return {
-            "name": "{}_{}".format(iteminfo_name, layer_meta.name),
+            "name": "{}_{}".format(iteminfo_name.encode(errors='ignore'), 
+                                   layer_meta.name.encode(errors='ignore')),
             "store": self.name,
             "storeType": "remoteStore",
             "workspace": "remoteWorkspace",


### PR DESCRIPTION
The following service fails to register because of an encoding error.
https://geohealth.hhs.gov/dataaccess/rest/services/HHS_emPOWER_REST_Service_Public/MapServer