### PR TITLE
GVSD-9061: Allow simultaneous wms and wfs urls for Services.

### DIFF
--- a/geonode/services/forms.py
+++ b/geonode/services/forms.py
@@ -32,6 +32,7 @@ from .serviceprocessors import get_service_handler
 from geonode.base.models import TopicCategory, License
 from geonode.base.enumerations import UPDATE_FREQUENCIES
 from django.conf import settings
+from django.db.models import Q
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,9 @@ class CreateServiceForm(forms.Form):
 
     def clean_url(self):
         proposed_url = self.cleaned_data["url"]
-        existing = Service.objects.filter(base_url=proposed_url).exists()
+        existing = Service.objects.filter(
+            Q(base_url=proposed_url) | Q(wms_url=proposed_url) |
+            Q(wfs_url=proposed_url)).exists()
         if existing:
             raise ValidationError(
                 _("Service %(url)s is already registered"),

--- a/geonode/services/migrations/0031_wfs_and_wms.py
+++ b/geonode/services/migrations/0031_wfs_and_wms.py
@@ -8,7 +8,7 @@ from urlparse import urlsplit, parse_qs
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('services', '0031_auto_20180809_1500'),
+        ('services', '0030_auto_20171212_0518'),
     ]
 
     def determine_base_url(apps, schema_editor):

--- a/geonode/services/migrations/0032_auto_20190319_0400.py
+++ b/geonode/services/migrations/0032_auto_20190319_0400.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from urlparse import urlsplit, parse_qs
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('services', '0031_auto_20180809_1500'),
+    ]
+
+    def determine_base_url(apps, schema_editor):
+        def is_wfs_url(url):
+            if 'WFSServer' in urlsplit(url).path:
+                return True
+            elif 'geoserver' in urlsplit(url).path:
+                query = parse_qs(urlsplit(url).query)
+                if 'service' in query:
+                    if query['service'] is 'wfs':
+                        return True
+            return False
+
+        def is_featureserver_url(url):
+            if 'FeatureServer' in urlsplit(url).path:
+                return True
+            return False
+
+        Service = apps.get_model("services", "Service")
+        for service in Service.objects.all():
+            if service.type == "REST":
+                if is_featureserver_url(service.base_url):
+                    service.wfs_url = service.base_url
+                else:
+                    service.wms_url = service.base_url
+            else:
+                if is_wfs_url(service.base_url):
+                    service.wfs_url = service.base_url
+                else:
+                    service.wms_url = service.base_url
+            service.save()
+
+    operations = [
+        migrations.AddField(
+            model_name='service',
+            name='wfs_url',
+            field=models.URLField(db_index=True, unique=True, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='service',
+            name='wms_url',
+            field=models.URLField(db_index=True, unique=True, null=True, blank=True),
+        ),
+        migrations.RunPython(determine_base_url),
+    ]

--- a/geonode/services/models.py
+++ b/geonode/services/models.py
@@ -61,6 +61,19 @@ class Service(ResourceBase):
         unique=True,
         db_index=True
     )
+    # allow a Service to have both a mapserver and featureserver endpoint
+    wms_url = models.URLField(
+        unique=True,
+        db_index=True,
+        null=True,
+        blank=True
+    )
+    wfs_url = models.URLField(
+        unique=True,
+        db_index=True,
+        null=True,
+        blank=True
+    )
     version = models.CharField(
         max_length=10,
         null=True,

--- a/geonode/services/templates/services/service_detail.html
+++ b/geonode/services/templates/services/service_detail.html
@@ -42,7 +42,12 @@ Ext.onReady(function() {
   <h3>{{service.title|default:service.name}}</h3>
       <p><strong>{% trans "Name:" %}</strong> {{service.name}}</p>
       <p><strong>{% trans "Type:" %}</strong> {{service.type}}</p>
-      <p><strong>{% trans "URL:" %}</strong> {{service.base_url}}</p>
+      {% if service.wms_url and service.wfs_url %}
+        <p><strong>{% trans "WMS_URL:" %}</strong> {{service.wms_url}}</p>
+        <p><strong>{% trans "WFS_URL:" %}</strong> {{service.wfs_url}}</p>
+      {% else %}
+        <p><strong>{% trans "URL:" %}</strong> {{service.base_url}}</p>
+      {% endif %}
       <p><strong>{% trans "Abstract:" %}</strong> {{service.abstract}}</p>
       <p><strong>{% trans "Keywords:" %}</strong> {{ service.keywords.all|join:", " }}</p>
       <p><strong>{% trans "Contact:" %}</strong> <a href="{% url "profile_detail" service.owner.username %}">{{ service.owner }}</a></p>

--- a/geonode/services/templates/services/service_list.html
+++ b/geonode/services/templates/services/service_list.html
@@ -21,7 +21,15 @@
   {% for service in services %}
   <tr>
       <td><a href='{% url "service_detail" service.id %}'>{{ service.title }}</a></td>
-      <td><a href='{{ service.base_url }}' target="_blank" rel="noopener noreferrer">{{ service.base_url|truncatechars:60 }}</a></td>
+      {% if service.wms_url and service.wfs_url %}
+        <td><strong>{% trans "WMS:" %}</strong>
+            <a href='{{ service.wms_url }}' target="_blank" rel="noopener noreferrer">{{ service.wms_url|truncatechars:60 }}</a>
+            <br/>
+            <strong>{% trans "WFS:" %}</strong>
+            <a href='{{ service.wfs_url }}' target="_blank" rel="noopener noreferrer">{{ service.wfs_url|truncatechars:60 }}</a></td>
+      {% else %}
+        <td><a href='{{ service.base_url }}' target="_blank" rel="noopener noreferrer">{{ service.base_url|truncatechars:60 }}</a></td>
+      {% endif %}
       <td>{{ service.type }}</td>
       <td><a href='{% url "service_detail" service.id %}'>{{ service.owner.username }}</a></td>
       <td><span class="badge">{{ service.layer_set.count }}</span></td>


### PR DESCRIPTION
Getting the GVSD-9061 incorporated into the exchange/1.4.x branch.

Squashed commit of the following:

commit fc8204b7adad816b243ddb3c92c10a6e0a84ed08
Author: Travis Brundage <travislbrundage@gmail.com>
Date:   Tue Mar 19 13:31:36 2019 -0700

    Update templates to use multiple service url endpoints

commit d088c41eb0d6d8ba5a8f3753d33031bf4c85c250
Author: Travis Brundage <travislbrundage@gmail.com>
Date:   Tue Mar 19 13:07:26 2019 -0700

    Update registration process - allow for registering of urls for existing service iff the url is not a direct duplicate; makes service handlers process wms and wfs urls simultaneously for single service

commit d5e03202b91178b94b54ef75f4573e74f1455361
Author: Travis Brundage <travislbrundage@gmail.com>
Date:   Tue Mar 19 13:00:45 2019 -0700

    Add migration for services to translate their base_url into wms or wfs url

commit 9dc39b1e1483452f6f0c52f02f9104159224597f
Author: Travis Brundage <travislbrundage@gmail.com>
Date:   Tue Mar 19 12:58:16 2019 -0700

    Add fields for wms and wfs url