### PR TITLE
1.4.20 bugfixes

### DIFF
--- a/geonode/groups/views.py
+++ b/geonode/groups/views.py
@@ -99,7 +99,7 @@ class GroupDetailView(ListView):
 
     def get(self, request, *args, **kwargs):
         self.group = get_object_or_404(GroupProfile, slug=kwargs.get('slug'))
-        if self.group.can_view(request.user):
+        if self.group.can_view(request.user) or request.user.is_superuser:
             return super(GroupDetailView, self).get(request, *args, **kwargs)
         else:
             raise Http404()

--- a/geonode/groups/views.py
+++ b/geonode/groups/views.py
@@ -192,7 +192,10 @@ def group_member_remove(request, slug, username):
         # Users can leave the group (remove themselves) on the group detail
         # page; otherwise, normal removals occur on the group members page
         if request.user.username == username:
-            return redirect("group_detail", slug=group.slug)
+            if group.access == "private":
+                return redirect("group_list")
+            else:
+                return redirect("group_detail", slug=group.slug)
         else:
             return redirect("group_members", slug=group.slug)
 

--- a/geonode/services/serviceprocessors/mapserver.py
+++ b/geonode/services/serviceprocessors/mapserver.py
@@ -216,8 +216,9 @@ class MapserverServiceHandler(base.ServiceHandlerBase,
         # ``pre_save`` signal for the Layer model. This handler does a check
         # for common fields (such as abstract and title) and adds
         # sensible default values
-        if layer_meta['defaultVisiblity']:
-            visibility = layer_meta['defaultVisiblity']
+        if 'defaultVisibility' in layer_meta \
+                and layer_meta['defaultVisibility'] is not None:
+            visibility = layer_meta['defaultVisibility']
         else:
             visibility = True
         geonode_layer = Layer(


### PR DESCRIPTION
Admins should be able to see groups in search and access their detail page - they can view them in the admin panel anyway.

If a user leaves a private group, they will no longer be able to see it, so redirect to the groups search list.